### PR TITLE
README.md: Update meta-python-dunfellplus rename to meta-python-mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please see the corresponding sections below for details.
 git clone https://github.com/openembedded/openembedded-core.git
 cd openembedded-core
 git clone https://github.com/openembedded/meta-openembedded.git
-git clone https://git.ostc-eu.org/OSTC/OHOS/meta-python-dunfellplus.git
+git clone https://booting.oniroproject.org/distro/meta-python-mixin.git
 git clone https://github.com/openembedded/bitbake.git
 git clone https://git.yoctoproject.org/git/meta-security
 git clone https://github.com/meta-homeassistant/meta-homeassistant.git
@@ -25,7 +25,7 @@ bitbake-layers add-layer ../meta-openembedded/meta-oe
 bitbake-layers add-layer ../meta-openembedded/meta-python
 bitbake-layers add-layer ../meta-openembedded/meta-networking
 bitbake-layers add-layer ../meta-openembedded/meta-perl
-bitbake-layers add-layer ../meta-python-dunfellplus
+bitbake-layers add-layer ../meta-python-mixin
 bitbake-layers add-layer ../meta-security
 bitbake-layers add-layer ../meta-homeassistant
 
@@ -48,7 +48,7 @@ URI: git://github.com/openembedded/meta-openembedded.git
 branch: dunfell
 revision: HEAD
 
-URI: https://git.ostc-eu.org/OSTC/OHOS/meta-python-dunfellplus.git
+URI: https://booting.oniroproject.org/distro/meta-python-mixin.git
 branch: dunfell
 revision: HEAD
 
@@ -66,7 +66,7 @@ Why are these needed?
 
 - [meta-oe (dunfell)](https://github.com/openembedded/meta-openembedded/tree/dunfell/meta-oe) : contains meta-python
 - [meta-python (dunfell)](https://github.com/openembedded/meta-openembedded/tree/dunfell/meta-python) : contains many of the required python3 packages
-- [meta-python-dunfellplus (dunfell)](https://git.ostc-eu.org/OSTC/OHOS/meta-python-dunfellplus/-/tree/dunfell) : contains meta-python backported recipe versions for dunfell
+- [meta-python-mixin (dunfell)](https://booting.oniroproject.org/distro/meta-python-mixin/-/tree/dunfell) : contains meta-python backported recipe versions for dunfell
 - [meta-security (dunfell)](http://git.yoctoproject.org/cgit/cgit.cgi/meta-security/log/?h=dunfell): required for nmap used for presence detection
 
 # Build configuration


### PR DESCRIPTION
The layer is also available in the index:
https://layers.openembedded.org/layerindex/branch/dunfell/layer/meta-python-mixin/