### PR TITLE
convert to new override syntax

### DIFF
--- a/kas-hass.yml
+++ b/kas-hass.yml
@@ -28,9 +28,9 @@ local_conf_header:
     INHERIT += "rm_work_and_downloads"
 
   Strip down unneeded features: |
-    POKY_DEFAULT_DISTRO_FEATURES_remove = "ptest"
-    POKY_DEFAULT_DISTRO_FEATURES_remove = "wayland"
-    DISTRO_FEATURES_DEFAULT_remove = "x11"
+    POKY_DEFAULT_DISTRO_FEATURES:remove = "ptest"
+    POKY_DEFAULT_DISTRO_FEATURES:remove = "wayland"
+    DISTRO_FEATURES_DEFAULT:remove = "x11"
 
   diskmon: |
     BB_DISKMON_DIRS = "\

--- a/kas-raspberrypi3.yml
+++ b/kas-raspberrypi3.yml
@@ -26,7 +26,7 @@ local_conf_header:
     RPI_USE_U_BOOT = "1"
     ENABLE_UART = "1"
     LICENSE_FLAGS_WHITELIST = "commercial"
-    IMAGE_INSTALL_append = " kernel-image kernel-modules"
+    IMAGE_INSTALL:append = " kernel-image kernel-modules"
 
   standard: |  
     PATCHRESOLVE = "noop"
@@ -34,13 +34,13 @@ local_conf_header:
     PACKAGE_CLASSES ?= "package_ipk"
     EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
     USER_CLASSES ?= "buildstats image-mklibs image-prelink"
-    PACKAGECONFIG_append_pn-qemu-native = " sdl"
-    PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
+    PACKAGECONFIG:append:pn-qemu-native = " sdl"
+    PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
     INHERIT += "image-buildinfo"
     IMAGE_ROOTFS_EXTRA_SPACE = "327680"
 
   systemd: |
-    DISTRO_FEATURES_append = " systemd"
+    DISTRO_FEATURES:append = " systemd"
     DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
     VIRTUAL-RUNTIME_init_manager = "systemd"
     VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"

--- a/recipes-devtools/python/python-aiohttp-jinja2.inc
+++ b/recipes-devtools/python/python-aiohttp-jinja2.inc
@@ -8,7 +8,7 @@ inherit pypi
 SRC_URI[md5sum] = "d8e0f9e824ab62f3bd17abb604f5884e"
 SRC_URI[sha256sum] = "4569ba360dbef2f6e2edfcb1eb34452e85498b7e17740baa5a4adc296ac3973c"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-jinja2 (>=2.7) \
     ${PYTHON_PN}-aiohttp (>=0.20) \
 "

--- a/recipes-devtools/python/python-astral.inc
+++ b/recipes-devtools/python/python-astral.inc
@@ -12,7 +12,7 @@ SRC_URI[sha256sum] = "d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51c
 # setup.py of astral requires it
 DEPENDS += "${PYTHON_PN}-pytz-native"
 
-RDEPENDS_${PN} +="\
+RDEPENDS:${PN} +="\
     ${PYTHON_PN}-pytz \
     ${PYTHON_PN}-requests \
 "

--- a/recipes-devtools/python/python-async-timeout.inc
+++ b/recipes-devtools/python/python-async-timeout.inc
@@ -14,6 +14,6 @@ SRC_URI[sha256sum] = "0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b2
 PYPI_PACKAGE = "async-timeout"
 inherit pypi
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-asyncio \
 "

--- a/recipes-devtools/python/python-bcrypt.inc
+++ b/recipes-devtools/python/python-bcrypt.inc
@@ -9,7 +9,7 @@ SRC_URI[sha256sum] = "0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13b
 
 inherit pypi
 
-RDEPENDS_${PN}_class-target += "\
+RDEPENDS:${PN}:class-target += "\
     ${PYTHON_PN}-cffi \
     ${PYTHON_PN}-ctypes \
     ${PYTHON_PN}-shell \

--- a/recipes-devtools/python/python-botocore.inc
+++ b/recipes-devtools/python/python-botocore.inc
@@ -9,7 +9,7 @@ SRC_URI[sha256sum] = "d49caf1dae7dd903c2af443dbafd76dcf3902d87236a83f8b64e77aa55
 
 inherit pypi
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-jmespath \
     ${PYTHON_PN}-dateutil \
     ${PYTHON_PN}-docutils \

--- a/recipes-devtools/python/python-cryptography.inc
+++ b/recipes-devtools/python/python-cryptography.inc
@@ -15,7 +15,7 @@ DEPENDS += " \
 SRC_URI[md5sum] = "7dfe1035cae43569e571318f000462a4"
 SRC_URI[sha256sum] = "e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6"
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-cffi \
     ${PYTHON_PN}-idna \
     ${PYTHON_PN}-asn1crypto \
@@ -23,7 +23,7 @@ RDEPENDS_${PN} += " \
     ${PYTHON_PN}-six \
 "
 
-RDEPENDS_${PN}_class-target += " \
+RDEPENDS:${PN}:class-target += " \
     ${PYTHON_PN}-cffi \
     ${PYTHON_PN}-idna \
     ${PYTHON_PN}-numbers \
@@ -33,7 +33,7 @@ RDEPENDS_${PN}_class-target += " \
     ${PYTHON_PN}-threading \
 "
 
-RDEPENDS_${PN}-ptest += " \
+RDEPENDS:${PN}-ptest += " \
     ${PN} \
     ${PYTHON_PN}-cryptography-vectors \
     ${PYTHON_PN}-iso8601 \
@@ -51,7 +51,7 @@ do_install_ptest() {
     cp -rf ${S}/tests/hazmat/* ${D}${PTEST_PATH}/tests/hazmat/
 }
 
-FILES_${PN}-dbg += " \
+FILES:${PN}-dbg += " \
     ${libdir}/${PYTHON_PN}2.7/site-packages/${SRCNAME}/hazmat/bindings/.debug \
 "
 

--- a/recipes-devtools/python/python-importlib-metadata.inc
+++ b/recipes-devtools/python/python-importlib-metadata.inc
@@ -13,7 +13,7 @@ DEPENDS += "\
     ${PYTHON_PN}-setuptools-scm-native \
 "
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-zipp \
     ${PYTHON_PN}-pathlib2 \
 "

--- a/recipes-devtools/python/python-jinja2.inc
+++ b/recipes-devtools/python/python-jinja2.inc
@@ -7,7 +7,7 @@ PYPI_PACKAGE = "Jinja2"
 SRC_URI[md5sum] = "0ae535be40fd215a8114a090c8b68e5a"
 SRC_URI[sha256sum] = "065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013"
 
-RDEPENDS_${PN} += "${PYTHON_PN}-io ${PYTHON_PN}-pickle ${PYTHON_PN}-crypt \
+RDEPENDS:${PN} += "${PYTHON_PN}-io ${PYTHON_PN}-pickle ${PYTHON_PN}-crypt \
     ${PYTHON_PN}-math ${PYTHON_PN}-netclient \
     ${PYTHON_PN}-pprint ${PYTHON_PN}-shell ${PYTHON_PN}-markupsafe \
     ${PYTHON_PN}-json ${PYTHON_PN}-threading ${PYTHON_PN}-numbers"

--- a/recipes-devtools/python/python-jmespath.inc
+++ b/recipes-devtools/python/python-jmespath.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2683790f5fabb41a3f75b70558799eb4"
 
 PR = "r0"
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-json \
     ${PYTHON_PN}-math \
     ${PYTHON_PN}-pprint \

--- a/recipes-devtools/python/python-netdisco.inc
+++ b/recipes-devtools/python/python-netdisco.inc
@@ -9,7 +9,7 @@ inherit pypi
 SRC_URI[md5sum] = "49c35f2a9102daf9f83c7e7315361373"
 SRC_URI[sha256sum] = "2b3aca14a1807712a053f11fd80dc251dd821ee4899aefece515287981817762"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-requests (>=2.0) \
     ${PYTHON_PN}-zeroconf (>=0.21.0) \
 "

--- a/recipes-devtools/python/python-pathlib2.inc
+++ b/recipes-devtools/python/python-pathlib2.inc
@@ -6,6 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=042856c23a3e903b33bf361ea1cbe29a"
 SRC_URI[md5sum] = "96da6398b3ea944417b84ccb25b171aa"
 SRC_URI[sha256sum] = "446014523bb9be5c28128c4d2a10ad6bb60769e78bd85658fe44a450674e0ef8"
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-six \
 "

--- a/recipes-devtools/python/python-pycryptodome.inc
+++ b/recipes-devtools/python/python-pycryptodome.inc
@@ -10,18 +10,18 @@ SRC_URI[sha256sum] = "b3cb4af317d9b84f6df50f0cfa6840ba69556af637a83fd971537823e1
 
 inherit pypi
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-io \
     ${PYTHON_PN}-math \
 "
 
-RDEPENDS_${PN}-tests += " \
+RDEPENDS:${PN}-tests += " \
     ${PYTHON_PN}-unittest \
 "
 
 PACKAGES =+ "${PN}-tests"
 
-FILES_${PN}-tests += " \
+FILES:${PN}-tests += " \
     ${PYTHON_SITEPACKAGES_DIR}/Crypto/SelfTest/ \
     ${PYTHON_SITEPACKAGES_DIR}/Crypto/SelfTest/__pycache__/ \
 "

--- a/recipes-devtools/python/python-pyjwt.inc
+++ b/recipes-devtools/python/python-pyjwt.inc
@@ -12,7 +12,7 @@ SRC_URI[sha256sum] = "8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cba
 PYPI_PACKAGE = "PyJWT"
 inherit setuptools3 pypi
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-cryptography (>= 1.4) \
 "
 

--- a/recipes-devtools/python/python-python-slugify.inc
+++ b/recipes-devtools/python/python-python-slugify.inc
@@ -10,7 +10,7 @@ inherit pypi
 SRC_URI[md5sum] = "d2f490f854f66cc723a004f5328a25b4"
 SRC_URI[sha256sum] = "a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-pycryptodome (>=3.3.1) \
     ${PYTHON_PN}-six (<2.0) \
     ${PYTHON_PN}-ecdsa (<1.0) \

--- a/recipes-devtools/python/python-pytz.inc
+++ b/recipes-devtools/python/python-pytz.inc
@@ -8,7 +8,7 @@ inherit pypi
 SRC_URI[md5sum] = "8c21963449c3a793aa61ef122e171516"
 SRC_URI[sha256sum] = "26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32"
 
-RDEPENDS_${PN}_class-target += "\
+RDEPENDS:${PN}:class-target += "\
     ${PYTHON_PN}-datetime \
     ${PYTHON_PN}-doctest \
     ${PYTHON_PN}-io \

--- a/recipes-devtools/python/python-pyyaml.inc
+++ b/recipes-devtools/python/python-pyyaml.inc
@@ -11,7 +11,7 @@ inherit pypi
 SRC_URI[md5sum] = "20f87ab421b0271dbf371dc5c1cddb5c"
 SRC_URI[sha256sum] = "01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4"
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-datetime \
 "
 

--- a/recipes-devtools/python/python-requests.inc
+++ b/recipes-devtools/python/python-requests.inc
@@ -3,14 +3,14 @@ HOMEPAGE = "http://python-requests.org"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a8d5a1d1c2d53025e2282c511033f6f7"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/python-requests:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/python-requests:"
 
 SRC_URI[md5sum] = "ee28bee2de76e9198fc41e48f3a7dd47"
 SRC_URI[sha256sum] = "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"
 
 inherit pypi
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-email \
     ${PYTHON_PN}-json \
     ${PYTHON_PN}-ndg-httpsclient \

--- a/recipes-devtools/python/python-ruamel-yaml.inc
+++ b/recipes-devtools/python/python-ruamel-yaml.inc
@@ -10,6 +10,6 @@ inherit pypi
 SRC_URI[md5sum] = "dd811a8f09dc0e622ad19a42508da7c1"
 SRC_URI[sha256sum] = "8e42f3067a59e819935a2926e247170ed93c8f0b2ab64526f888e026854db2e4"
 
-do_install_prepend() {
+do_install:prepend() {
     export RUAMEL_NO_PIP_INSTALL_CHECK=1
 }

--- a/recipes-devtools/python/python-sqlalchemy.inc
+++ b/recipes-devtools/python/python-sqlalchemy.inc
@@ -10,7 +10,7 @@ inherit pypi
 SRC_URI[md5sum] = "c869817feddc7b0d3ae9ed23cf86997d"
 SRC_URI[sha256sum] = "c4cca4aed606297afbe90d4306b49ad3a4cd36feb3f87e4bfd655c57fd9ef445"
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-json \
     ${PYTHON_PN}-pickle \
     ${PYTHON_PN}-logging \

--- a/recipes-devtools/python/python-voluptuous.inc
+++ b/recipes-devtools/python/python-voluptuous.inc
@@ -8,7 +8,7 @@ inherit pypi
 SRC_URI[md5sum] = "695928b25384deba7c3d5e4de3520ab1"
 SRC_URI[sha256sum] = "2abc341dbc740c5e2302c7f9b8e2e243194fb4772585b991931cb5b22e9bf456"
 
-do_install_append () {
+do_install:append () {
     # Files in the tarball are not world readable
     chmod -R a+r ${D}${libdir}
 }

--- a/recipes-devtools/python/python-websocket-client.inc
+++ b/recipes-devtools/python/python-websocket-client.inc
@@ -13,6 +13,6 @@ SRC_URI[sha256sum] = "1fd5520878b68b84b5748bb30e592b10d0a91529d5383f74f4964e72b2
 PYPI_PACKAGE = "websocket_client"
 inherit pypi
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-six \
 "

--- a/recipes-devtools/python/python-zeroconf.inc
+++ b/recipes-devtools/python/python-zeroconf.inc
@@ -8,6 +8,6 @@ inherit pypi
 SRC_URI[md5sum] = "1eae70b5291cdd0dc4292781ec051cc3"
 SRC_URI[sha256sum] = "893a841445663e0c4c20d1111ce41484bd62d58f59d653d0485187343368ef4a"
 
-RDEPENDS_${PN} = " \
+RDEPENDS:${PN} = " \
     ${PYTHON_PN}-ifaddr \
 "

--- a/recipes-devtools/python/python-zipp.inc
+++ b/recipes-devtools/python/python-zipp.inc
@@ -7,4 +7,4 @@ SRC_URI[md5sum] = "d4451a749d8a7c3c392a9edd1864a937"
 SRC_URI[sha256sum] = "3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e"
 
 DEPENDS += "${PYTHON_PN}-setuptools-scm-native"
-RDEPENDS_${PN} += "${PYTHON_PN}-more-itertools"
+RDEPENDS:${PN} += "${PYTHON_PN}-more-itertools"

--- a/recipes-devtools/python/python3-acme_0.39.0.bb
+++ b/recipes-devtools/python/python3-acme_0.39.0.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "75a6659bce20e757bb7387105d4b4b66"
 SRC_URI[sha256sum] = "a2fcb75d16de6804f4b4d773a457ee2f6434ebaf8fd1aa60862a91d4e8f73608"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-cryptography (>=1.2.3) \
     ${PYTHON_PN}-josepy (>=1.1.0) \
     ${PYTHON_PN}-pyopenssl (>=0.13.1) \

--- a/recipes-devtools/python/python3-aiohttp-cors_0.7.0.bb
+++ b/recipes-devtools/python/python3-aiohttp-cors_0.7.0.bb
@@ -8,6 +8,6 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "de3940a901b269be82c8bd9f28d53ff0"
 SRC_URI[sha256sum] = "4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-aiohttp (>=1.1) \
 "

--- a/recipes-devtools/python/python3-aiohttp_3.6.1.bb
+++ b/recipes-devtools/python/python3-aiohttp_3.6.1.bb
@@ -10,7 +10,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "a3706ef8dc9128ed98dcb6bfe1c8e116"
 SRC_URI[sha256sum] = "fc55b1fec0e4cc1134ffb09ea3970783ee2906dc5dfd7cd16917913f2cfed65b"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-attrs (>=17.3.0) \
     ${PYTHON_PN}-chardet (>=2.0) \
     ${PYTHON_PN}-multidict (>=4.0) \

--- a/recipes-devtools/python/python3-async-upnp-client_0.14.12.bb
+++ b/recipes-devtools/python/python3-async-upnp-client_0.14.12.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/async_upnp_client-${PV}"
 SRC_URI[md5sum] = "5d1bae23edb2269992ad42040438616c"
 SRC_URI[sha256sum] = "99f4f371d20c418940c21f79290fabd4e5b6eb37460b7eee12aaa502bd3ee1b9"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-async-timeout (>=3.0.0) \
 	${PYTHON_PN}-python-didl-lite (>=1.2.4) \
 	${PYTHON_PN}-defusedxml (>=0.5.0) \

--- a/recipes-devtools/python/python3-boto3_1.12.29.bb
+++ b/recipes-devtools/python/python3-boto3_1.12.29.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "9ec881a10da7c4e56f7af015acf782ce"
 SRC_URI[sha256sum] = "f31e10348909dd4dbe0e75ecd695a78c13dc4b49712cf90048a9e0ae80a4a84d"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-botocore (>=1.15.29) \
     ${PYTHON_PN}-jmespath (>=0.7.1) \
     ${PYTHON_PN}-s3transfer (>=0.2.0) \

--- a/recipes-devtools/python/python3-ciso8601_2.1.3.bb
+++ b/recipes-devtools/python/python3-ciso8601_2.1.3.bb
@@ -7,6 +7,6 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "5d6434ad5ba5d54167aaa96b3503d81e"
 SRC_URI[sha256sum] = "bdbb5b366058b1c87735603b23060962c439ac9be66f1ae91e8c7dbd7d59e262"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-pytz (>=2019.03) \
 "

--- a/recipes-devtools/python/python3-coronavirus_1.1.0.bb
+++ b/recipes-devtools/python/python3-coronavirus_1.1.0.bb
@@ -6,6 +6,6 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "fce49db800fa7d17786346aba083e2b7"
 SRC_URI[sha256sum] = "38f47bed399967329d06a784081b427e94a5055ad7487875fb8af8b58d4db611"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-aiohttp (>=3.0.0) \
 "

--- a/recipes-devtools/python/python3-daemonize_2.4.7.bb
+++ b/recipes-devtools/python/python3-daemonize_2.4.7.bb
@@ -5,7 +5,7 @@ SRCNAME = "daemonize"
 
 inherit pypi setuptools3
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
                python3-fcntl \
                python3-unixadmin \
                python3-logging \

--- a/recipes-devtools/python/python3-ecdsa_0.13.2.bb
+++ b/recipes-devtools/python/python3-ecdsa_0.13.2.bb
@@ -13,7 +13,7 @@ DEPENDS += " \
     ${PYTHON_PN}-pbr \
 "
 
-# RDEPENDS_default:
-RDEPENDS_${PN} += " \
+# RDEPENDS:default:
+RDEPENDS:${PN} += " \
     ${PYTHON_PN}-pbr \
 "

--- a/recipes-devtools/python/python3-gtts-token_1.1.3.bb
+++ b/recipes-devtools/python/python3-gtts-token_1.1.3.bb
@@ -10,6 +10,6 @@ S = "${WORKDIR}/gTTS-token-${PV}"
 SRC_URI[md5sum] = "2d21ca76976f9e803d3ec7fd6ca4f303"
 SRC_URI[sha256sum] = "9d6819a85b813f235397ef931ad4b680f03d843c9b2a9e74dd95175a4bc012c5"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-requests (>=2.22.0) \
 "

--- a/recipes-devtools/python/python3-hass-nabucasa_0.32.2.bb
+++ b/recipes-devtools/python/python3-hass-nabucasa_0.32.2.bb
@@ -7,7 +7,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "7c5dea602de4ea888c8fbe63adfc25cb"
 SRC_URI[sha256sum] = "c9093ef803fc98737b95aee9a0bf74eedbecd74b9579567759faaddd165bdd92"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-warrant (>=0.6.1) \
     ${PYTHON_PN}-snitun (>=0.18) \
     ${PYTHON_PN}-acme (>=0.32.0) \

--- a/recipes-devtools/python/python3-jmespath_0.9.3.bb
+++ b/recipes-devtools/python/python3-jmespath_0.9.3.bb
@@ -1,10 +1,10 @@
 inherit pypi setuptools3 update-alternatives
 require python-jmespath.inc
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-stringold \
 "
 
-ALTERNATIVE_${PN} = "jmespath"
+ALTERNATIVE:${PN} = "jmespath"
 ALTERNATIVE_LINK_NAME[jmespath] = "${bindir}/jp.py"
 ALTERNATIVE_PRIORITY = "30"

--- a/recipes-devtools/python/python3-josepy_1.2.0.bb
+++ b/recipes-devtools/python/python3-josepy_1.2.0.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "d9a65fb86fba3e79af3724f375e9e7e1"
 SRC_URI[sha256sum] = "9cec9a839fe9520f0420e4f38e7219525daccce4813296627436fe444cd002d3"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-cryptography (>=0.8) \
     ${PYTHON_PN}-pyopenssl (>=0.13) \
 "

--- a/recipes-devtools/python/python3-pycognito_0.1.2.bb
+++ b/recipes-devtools/python/python3-pycognito_0.1.2.bb
@@ -6,7 +6,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "3a6d8ac4ea82f24071b228519b6eadd4"
 SRC_URI[sha256sum] = "cc1bac3818baabc1dce46c3fb1147d7ec905ae6c2dbabc5f4e8af4c034394e77"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-boto3 (>=1.10.49) \
 	${PYTHON_PN}-requests (>=2.22.0) \
 	${PYTHON_PN}-six (>=1.10.0) \

--- a/recipes-devtools/python/python3-pymetno_0.5.0.bb
+++ b/recipes-devtools/python/python3-pymetno_0.5.0.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/PyMetno-${PV}"
 SRC_URI[md5sum] = "9fe0910f68c0f04080f3228cca9ab0f4"
 SRC_URI[sha256sum] = "e532544495200210407e3d68f719c271435da6f3bfe696e708b1d5d603a21948"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-aiohttp (>=3.6.1) \
 	${PYTHON_PN}-async-timeout (>=3.0.1) \
 	${PYTHON_PN}-pytz (>=2019.3) \

--- a/recipes-devtools/python/python3-pynacl_1.3.0.bb
+++ b/recipes-devtools/python/python3-pynacl_1.3.0.bb
@@ -16,16 +16,16 @@ DEPENDS += "\
     libsodium \
 "
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-six \
     ${PYTHON_PN}-cffi (>=1.4.1) \
     libsodium \
 "
 
-do_compile_prepend() {
+do_compile:prepend() {
     export SODIUM_INSTALL=system
 }
 
-do_install_prepend() {
+do_install:prepend() {
     export SODIUM_INSTALL=system
 }

--- a/recipes-devtools/python/python3-pyrfc3339_1.1.bb
+++ b/recipes-devtools/python/python3-pyrfc3339_1.1.bb
@@ -10,6 +10,6 @@ PYPI_PACKAGE = "pyRFC3339"
 SRC_URI[md5sum] = "c829980738b8271b0179ffd0c41187b0"
 SRC_URI[sha256sum] = "81b8cbe1519cdb79bed04910dd6fa4e181faf8c88dff1e1b987b5f7ab23a5b1a"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-pytz \
 "

--- a/recipes-devtools/python/python3-python-didl-lite_1.2.4.bb
+++ b/recipes-devtools/python/python3-python-didl-lite_1.2.4.bb
@@ -6,6 +6,6 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "a408de47eef6bce0e3d19a3e9ebe6c23"
 SRC_URI[sha256sum] = "04a3911cba7ac457e4b499b34fae461a2ba5eab9d4e97ed5c8310844e18474a6"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-defusedxml (>=0.5.0) \
 "

--- a/recipes-devtools/python/python3-s3transfer_0.2.1.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.2.1.bb
@@ -1,6 +1,6 @@
 inherit setuptools3
 require python-s3transfer.inc
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
     ${PYTHON_PN}-multiprocessing \
 "

--- a/recipes-devtools/python/python3-samsungtv_1.0.0.bb
+++ b/recipes-devtools/python/python3-samsungtv_1.0.0.bb
@@ -6,7 +6,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "5280bf6ffcc20547ca18acb9ecaf0771"
 SRC_URI[sha256sum] = "4ad609039b206399c9c44ef2131c78580a0077499f94e9b1b3aa80b03dd67f83"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-websocket-client (>=0.56.0) \
 	${PYTHON_PN}-six (>=1.14.0) \
 "

--- a/recipes-devtools/python/python3-samsungtvws_1.4.0.bb
+++ b/recipes-devtools/python/python3-samsungtvws_1.4.0.bb
@@ -6,7 +6,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "e0fab14cc0d0a7a34bc23fc2a5c90a0b"
 SRC_URI[sha256sum] = "5b84d6bf285b4dde43468d9687e0fef7206bda4d50e4ac1e70a56c49de7c5e44"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-websocket-client (>=0.56.0) \
 	${PYTHON_PN}-requests (>=2.21.0) \
 "

--- a/recipes-devtools/python/python3-snitun_0.20.bb
+++ b/recipes-devtools/python/python3-snitun_0.20.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "fb7f29738c1535e21b3f1067bc5c77c2"
 SRC_URI[sha256sum] = "c74f4ff82f8e106859652d0f7207e0533137742ab300693198909b37c097c27b"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-attrs (>=18.2.0) \
     ${PYTHON_PN}-async-timeout (>=3.0.1) \
     ${PYTHON_PN}-cryptography (>=2.5) \

--- a/recipes-devtools/python/python3-spotipy_2.10.0.bb
+++ b/recipes-devtools/python/python3-spotipy_2.10.0.bb
@@ -6,7 +6,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "9e51cef7016db08a972ddd804f07f386"
 SRC_URI[sha256sum] = "f5bd0d04f4fd37d3b38cd3b35d2e9ce05182a57bc52403d6bad14d07bb4f4e68"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
 	${PYTHON_PN}-chardet (>=3.0.2) \
 	${PYTHON_PN}-requests (>=2.22.0) \
 	${PYTHON_PN}-six (>=1.10.0) \

--- a/recipes-devtools/python/python3-ssdp_1.0.1.bb
+++ b/recipes-devtools/python/python3-ssdp_1.0.1.bb
@@ -8,6 +8,6 @@ SRC_URI[sha256sum] = "7325a2e850339c97bde23e923f7908be5f3453745d9ce8905a956f2f93
 
 SRC_URI += "file://0001-fix-build.patch"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-pbr (>=5.4.0) \
     "

--- a/recipes-devtools/python/python3-user-agents_1.1.0.bb
+++ b/recipes-devtools/python/python3-user-agents_1.1.0.bb
@@ -8,6 +8,6 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "0f18f7edf132605d1d43cc56d4850c31"
 SRC_URI[sha256sum] = "643d16772280052b546d956971d719989ef6dc9b17d9ff0386aa21391a038039"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-ua-parser \
 "

--- a/recipes-devtools/python/python3-warrant_0.6.1.bb
+++ b/recipes-devtools/python/python3-warrant_0.6.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/capless/warrant"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://setup.py;md5=d781fd54312fe4e227a093bdcaa7b4fd"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 inherit pypi setuptools3
 
@@ -14,7 +14,7 @@ SRC_URI += "\
     file://0001-Remove-pip-requires.patch \
 "
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-boto3 (>=1.4.3) \
     ${PYTHON_PN}-envs (>=0.3.0) \
     ${PYTHON_PN}-python-jose-cryptodome (>=1.3.2) \

--- a/recipes-devtools/python/python3-yarl_1.3.0.bb
+++ b/recipes-devtools/python/python3-yarl_1.3.0.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "92889c31fce4c8f82b7ee9c2b2ed9cd1"
 SRC_URI[sha256sum] = "024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-multidict (>=4.0) \
     ${PYTHON_PN}-idna (>=2.0) \
 "

--- a/recipes-homeassistant/homeassistant/python3-appdaemon_3.0.5.bb
+++ b/recipes-homeassistant/homeassistant/python3-appdaemon_3.0.5.bb
@@ -10,7 +10,7 @@ inherit pypi
 SRC_URI[md5sum] = "cfceac58b705dba5b828e83010b2a1d1"
 SRC_URI[sha256sum] = "623897ce08dc2efe24d04380df36e4b7fb35c0e4007e882857d4047f0b60349d"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-aiohttp \
     ${PYTHON_PN}-aiohttp-jinja2 \
     ${PYTHON_PN}-async \

--- a/recipes-homeassistant/homeassistant/python3-home-assistant-frontend_20200318.1.bb
+++ b/recipes-homeassistant/homeassistant/python3-home-assistant-frontend_20200318.1.bb
@@ -8,6 +8,6 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "a792c7657ed86f7e84a70739a6221653"
 SRC_URI[sha256sum] = "edb3dd2c8bfebeacad2754b185d647733a179d85a391a2153edf841ef1e4592e"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-user-agents \
 "

--- a/recipes-homeassistant/homeassistant/python3-homeassistant_0.107.6.bb
+++ b/recipes-homeassistant/homeassistant/python3-homeassistant_0.107.6.bb
@@ -22,17 +22,17 @@ SRC_URI += "\
     "
 
 USERADD_PACKAGES = "${PN}"
-GROUPADD_PARAM_${PN} = "homeassistant"
-USERADD_PARAM_${PN} = "--system --home ${HOMEASSISTANT_CONFIG_DIR} \
+GROUPADD_PARAM:${PN} = "homeassistant"
+USERADD_PARAM:${PN} = "--system --home ${HOMEASSISTANT_CONFIG_DIR} \
                        --no-create-home --shell /bin/false \
                        --groups homeassistant,dialout --gid homeassistant ${HOMEASSISTANT_USER}"
 
 INITSCRIPT_NAME = "homeassistant"
 
 SYSTEMD_AUTO_ENABLE = "enable"
-SYSTEMD_SERVICE_${PN} = "homeassistant.service"
+SYSTEMD_SERVICE:${PN} = "homeassistant.service"
 
-do_install_append () {
+do_install:append () {
     install -d -o ${HOMEASSISTANT_USER} -g homeassistant ${D}${HOMEASSISTANT_CONFIG_DIR}
 
     # Install init scripts and set correct config directory
@@ -49,7 +49,7 @@ do_install_append () {
 }
 
 # Home Assistant core
-RDEPENDS_${PN} = " \
+RDEPENDS:${PN} = " \
     ${PYTHON_PN}-pyjwt (>=1.7.1) \
     ${PYTHON_PN}-aiohttp (>=3.6.1) \
     ${PYTHON_PN}-aiohttp-cors (>=0.7.0) \

--- a/recipes-integrations/python/python-python-telegram-bot.inc
+++ b/recipes-integrations/python/python-python-telegram-bot.inc
@@ -12,7 +12,7 @@ inherit pypi
 SRC_URI[md5sum] = "a1c6470f913dc18b5b4ba38531c09c8d"
 SRC_URI[sha256sum] = "cca4e32ebb8da7fdf35ab2fa2b3edd441211364819c5592fc253acdb7561ea5b"
 
-RDEPENDS_${PN} = "\
+RDEPENDS:${PN} = "\
     ${PYTHON_PN}-future \
     ${PYTHON_PN}-certifi \
     ${PYTHON_PN}-ujson \


### PR DESCRIPTION
This is the result of running

  ../meta-poky/scripts/contrib/convert-overrides.py .

as of meta-poky commit 86ae0ef3da. The meta-poky gatesgarth branch, as
of commit f2d2136dbb, accepts : as an alias for _, so this should
still be gatesgarth compatible.