### PR TITLE
License fixups

### DIFF
--- a/recipes-devtools/python/python3-async-upnp-client_0.14.12.bb
+++ b/recipes-devtools/python/python3-async-upnp-client_0.14.12.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=f4eda51018051de136d3b3742e9a7a40"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-ciso8601_2.1.3.bb
+++ b/recipes-devtools/python/python3-ciso8601_2.1.3.bb
@@ -1,6 +1,6 @@
 HOMEPAGE = "https://www./"
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=650b6b7ede4fbd14ab012aceb71d69d7"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-coronavirus_1.1.0.bb
+++ b/recipes-devtools/python/python3-coronavirus_1.1.0.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=10abb65256392e3f6889e706d0f753b2"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-envs_1.3.bb
+++ b/recipes-devtools/python/python3-envs_1.3.bb
@@ -2,8 +2,8 @@ DESCRIPTION = "Easy access of environment variables from Python with support \
 for typing (ex. booleans, strings, lists, tuples, integers, floats, and \
 dicts). Now with CLI settings file converter."
 HOMEPAGE = "https://github.com/capless/envs"
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-gtts-token_1.1.3.bb
+++ b/recipes-devtools/python/python3-gtts-token_1.1.3.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a5eb74eb0b84de9e63b66147166bc4b5"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-hass-nabucasa_0.32.2.bb
+++ b/recipes-devtools/python/python3-hass-nabucasa_0.32.2.bb
@@ -1,6 +1,6 @@
 HOMEPAGE = "https://www.nabucasa.com/"
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=8ce93f51d70fd2b9add4f5b93af43d4a"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-mutagen_1.44.0.bb
+++ b/recipes-devtools/python/python3-mutagen_1.44.0.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-pycognito_0.1.2.bb
+++ b/recipes-devtools/python/python3-pycognito_0.1.2.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=7145f7cdd263359b62d342a02f005515"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-pymetno_0.5.0.bb
+++ b/recipes-devtools/python/python3-pymetno_0.5.0.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-python-didl-lite_1.2.4.bb
+++ b/recipes-devtools/python/python3-python-didl-lite_1.2.4.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=f4eda51018051de136d3b3742e9a7a40"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-samsungctl_0.7.1.bb
+++ b/recipes-devtools/python/python3-samsungctl_0.7.1.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d15899171de611ea06093a47d5fb4419"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-samsungtv_1.0.0.bb
+++ b/recipes-devtools/python/python3-samsungtv_1.0.0.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=7;endline=7;md5=8227180126797a0148f94f483f3e1489"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-samsungtvws_1.4.0.bb
+++ b/recipes-devtools/python/python3-samsungtvws_1.4.0.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=7;endline=7;md5=adc1f231c76ee2f1f36025d56926ba2c"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-spotipy_2.10.0.bb
+++ b/recipes-devtools/python/python3-spotipy_2.10.0.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=b46291b1d43fe22e63a77b034d62aa58"
 
 inherit pypi setuptools3
 

--- a/recipes-devtools/python/python3-ssdp_1.0.1.bb
+++ b/recipes-devtools/python/python3-ssdp_1.0.1.bb
@@ -1,5 +1,5 @@
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=98ceae65d56131ed6c7782a772389c12"
 
 inherit pypi setuptools3
 


### PR DESCRIPTION
While trying to build against meta-poky honister, I came across lots of recipes that pointed their LIC_FILES_CHECKSUM at the now-non-existent `common-licenses/GPL-3.0` file. In most of those cases, the license isn't GPL-3 anyway (neither -only or -or-later) - most are either MIT or Apache-2.0.

This should be entirely safe for the dunfell branch, so I've broken out those fixes. From there, it's only three minor fetch fixups and a perhaps dubious requirement hack to get something that will build and install against honister.