### PR TITLE
Convert systemd service to 'simple' type to avoid restarts

### DIFF
--- a/recipes-homeassistant/homeassistant/files/homeassistant.service
+++ b/recipes-homeassistant/homeassistant/files/homeassistant.service
@@ -3,7 +3,7 @@ Description=Home Assistant
 After=network.target
 
 [Service]
-Type=notify
+Type=simple
 User=@HOMEASSISTANT_USER@
 ExecStart=/usr/bin/hass --skip-pip -c "@HOMEASSISTANT_CONFIG_DIR@"
 Restart=on-failure


### PR DESCRIPTION
sd_notify support has been removed here: https://github.com/meta-homeassistant/meta-homeassistant/commit/b515ca279690d04f1473caba6ab67df20d109aea

Hence systemd is not notified anymore when homeassistant has started up. With a Type=notify service this means that after a given time systemd will consider the service timed-out and will restart it.

Switching to the simple type will avoid the restarts.