### PR TITLE
fixed python3-orjson to correctly

### DIFF
--- a/recipes-devtools/python/python3-orjson_3.8.7.bb
+++ b/recipes-devtools/python/python3-orjson_3.8.7.bb
@@ -72,5 +72,11 @@ SRC_URI[smallvec-1.10.0.sha256sum] = "a507befe795404456341dfab10cef66ead4c041f62
 SRC_URI[target-lexicon-0.12.6.sha256sum] = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 SRC_URI[version_check-0.9.4.sha256sum] = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
-inherit pypi python_pyo3 python_setuptools_build_meta cargo 
-# inherit pypi cargo python_setuptools_build_meta python_pyo3
+DEPENDS += "python3-setuptools-rust-native"
+
+inherit cargo pypi python_pyo3 python_setuptools_build_meta
+
+do_configure() {
+    python_pyo3_do_configure
+    cargo_common_do_configure
+}


### PR DESCRIPTION
Fixes #73 .

Finally figured out how to fix this. How to partially reimplement parts of python3_setuptools_rust, except for the fact that it should skip the python3_setuptools configuration step as this would incorrectly configure the package.