### PR TITLE
python3-maturin: fix compilation

### DIFF
--- a/recipes-devtools/python/python3-maturin-native_1.2.3.bb
+++ b/recipes-devtools/python/python3-maturin-native_1.2.3.bb
@@ -171,6 +171,7 @@ SRC_URI:append = " \
     crate://crates.io/rand_core/0.6.4 \
     crate://crates.io/rayon/1.7.0 \
     crate://crates.io/rayon-core/1.11.0 \
+    crate://crates.io/redox_syscall/0.2.16;name=redox_syscall_0.2.16 \
     crate://crates.io/redox_syscall/0.3.5 \
     crate://crates.io/redox_users/0.4.3 \
     crate://crates.io/regex/1.7.3 \
@@ -273,6 +274,7 @@ SRC_URI:append = " \
     crate://crates.io/winapi-i686-pc-windows-gnu/0.4.0 \
     crate://crates.io/winapi-util/0.1.5 \
     crate://crates.io/winapi-x86_64-pc-windows-gnu/0.4.0 \
+    crate://crates.io/windows-sys/0.45.0;name=windows-sys_0.45.0 \
     crate://crates.io/windows-sys/0.48.0 \
     crate://crates.io/windows-targets/0.42.2 \
     crate://crates.io/windows-targets/0.48.2;name=windows-targets_0.48.2 \
@@ -460,6 +462,7 @@ SRC_URI[rand_chacha-0.3.1.sha256sum] = "e6c10a63a0fa32252be49d21e7709d4d4baf8d23
 SRC_URI[rand_core-0.6.4.sha256sum] = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 SRC_URI[rayon-1.7.0.sha256sum] = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 SRC_URI[rayon-core-1.11.0.sha256sum] = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+SRC_URI[redox_syscall_0.2.16.sha256sum] = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 SRC_URI[redox_syscall-0.3.5.sha256sum] = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 SRC_URI[redox_users-0.4.3.sha256sum] = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 SRC_URI[regex-1.7.3.sha256sum] = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
@@ -562,6 +565,7 @@ SRC_URI[winapi-0.3.9.sha256sum] = "5c839a674fcd7a98952e593242ea400abe93992746761
 SRC_URI[winapi-i686-pc-windows-gnu-0.4.0.sha256sum] = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 SRC_URI[winapi-util-0.1.5.sha256sum] = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 SRC_URI[winapi-x86_64-pc-windows-gnu-0.4.0.sha256sum] = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+SRC_URI[windows-sys_0.45.0.sha256sum] = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 SRC_URI[windows-sys-0.48.0.sha256sum] = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 SRC_URI[windows-targets-0.42.2.sha256sum] = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 SRC_URI[windows-targets_0.48.2.sha256sum] = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"


### PR DESCRIPTION
As is, this doesn't work for me:
| cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --target x86_64-unknown-linux-gnu --release -v --no-default-features --locked | error: failed to select a version for the requirement `windows-sys = "^0.45.0"` (locked to 0.45.0) | candidate versions found which didn't match: 0.48.0 | location searched: directory source `<yocto-workdir>/python3-maturin-native/1.2.3-r0/cargo_home/bitbake` (which is replacing registry `crates-io`) | required by package `console v0.15.7`
|     ... which satisfies dependency `console = "^0.15.4"` (locked to 0.15.7) of package `maturin v1.2.3 (<yocto-workdir>/python3-maturin-native/1.2.3-r0/maturin-1.2.3)`
| perhaps a crate was updated and forgotten to be re-vendored?
| error: `cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --target x86_64-unknown-linux-gnu --release -v --no-default-features --locked` failed with code 101
| ERROR: 'python3 setup.py bdist_wheel ' execution failed.

and

| cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --target x86_64-unknown-linux-gnu --release -v --no-default-features --locked | error: failed to select a version for the requirement `redox_syscall = "^0.2.11"` (locked to 0.2.16) | candidate versions found which didn't match: 0.3.5 | location searched: directory source `<yocto-workdir>/python3-maturin-native/1.2.3-r0/cargo_home/bitbake` (which is replacing registry `crates-io`) | required by package `redox_users v0.4.3`
|     ... which satisfies dependency `redox_users = "^0.4"` (locked to 0.4.3) of package `dirs-sys v0.4.1`
|     ... which satisfies dependency `dirs-sys = "^0.4.1"` (locked to 0.4.1) of package `dirs v5.0.1`
|     ... which satisfies dependency `dirs = "^5.0.0"` (locked to 5.0.1) of package `cargo-xwin v0.14.6`
|     ... which satisfies dependency `cargo-xwin = "^0.14.3"` (locked to 0.14.6) of package `maturin v1.2.3 (<yocto-workdir>/python3-maturin-native/1.2.3-r0/maturin-1.2.3)`
| perhaps a crate was updated and forgotten to be re-vendored?
| error: `cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --target x86_64-unknown-linux-gnu --release -v --no-default-features --locked` failed with code 101
| ERROR: 'python3 setup.py bdist_wheel ' execution failed.

Add the missing version