### PR TITLE
Drop python names

### DIFF
--- a/recipes-devtools/python/python3-acme_2.7.1.bb
+++ b/recipes-devtools/python/python3-acme_2.7.1.bb
@@ -8,10 +8,10 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "47aea91999434cb01a3530c7c76866f387fdb818097808704d6cfa98dbe4e966"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-cryptography (>=3.2.1) \
-    ${PYTHON_PN}-josepy (>=1.13.0) \
-    ${PYTHON_PN}-pyopenssl (>=17.5.0) \
-    ${PYTHON_PN}-pyrfc3339 \
-    ${PYTHON_PN}-pytz (>=2019.3) \
-    ${PYTHON_PN}-requests (>=2.20.0) \
+    python3-cryptography (>=3.2.1) \
+    python3-josepy (>=1.13.0) \
+    python3-pyopenssl (>=17.5.0) \
+    python3-pyrfc3339 \
+    python3-pytz (>=2019.3) \
+    python3-requests (>=2.20.0) \
 "

--- a/recipes-devtools/python/python3-aiodiscover_1.5.1.bb
+++ b/recipes-devtools/python/python3-aiodiscover_1.5.1.bb
@@ -12,9 +12,9 @@ DEPENDS += "\
 SRC_URI[sha256sum] = "1aa795293fe6dcb06fd3d1cc035a8a6b37b40c671ba442feffd5ade20ff995f6"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-async-timeout (>=4.0.1) \
-    ${PYTHON_PN}-netifaces (>=0.11.0) \
-    ${PYTHON_PN}-dnspython (>=2.3.0) \
-    ${PYTHON_PN}-ifaddr \
-    ${PYTHON_PN}-pyroute2 (>=0.7.3) \
+    python3-async-timeout (>=4.0.1) \
+    python3-netifaces (>=0.11.0) \
+    python3-dnspython (>=2.3.0) \
+    python3-ifaddr \
+    python3-pyroute2 (>=0.7.3) \
 "

--- a/recipes-devtools/python/python3-aiogithubapi_22.10.1.bb
+++ b/recipes-devtools/python/python3-aiogithubapi_22.10.1.bb
@@ -9,11 +9,11 @@ SRC_URI[sha256sum] = "327c79287d10e985855c0b31702efad666b55ad223241efdf28af32695
 inherit pypi python_setuptools_build_meta python_poetry_core
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiosignal (>=1.1.2) \
-    ${PYTHON_PN}-async-timeout (>=4.0.0a3) \
-    ${PYTHON_PN}-attrs (>=17.3.0) \
-    ${PYTHON_PN}-charset-normalizer (>=2.0) \
-    ${PYTHON_PN}-frozenlist (>=1.1.1) \
-    ${PYTHON_PN}-multidict (>=4.5) \
-    ${PYTHON_PN}-yarl (>=1.0) \
+    python3-aiosignal (>=1.1.2) \
+    python3-async-timeout (>=4.0.0a3) \
+    python3-attrs (>=17.3.0) \
+    python3-charset-normalizer (>=2.0) \
+    python3-frozenlist (>=1.1.1) \
+    python3-multidict (>=4.5) \
+    python3-yarl (>=1.0) \
 "

--- a/recipes-devtools/python/python3-aiohttp-cors_0.7.0.bb
+++ b/recipes-devtools/python/python3-aiohttp-cors_0.7.0.bb
@@ -9,5 +9,5 @@ SRC_URI[md5sum] = "de3940a901b269be82c8bd9f28d53ff0"
 SRC_URI[sha256sum] = "4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiohttp (>=1.1) \
+    python3-aiohttp (>=1.1) \
 "

--- a/recipes-devtools/python/python3-aiohttp-fast-url-dispatcher_0.3.0.bb
+++ b/recipes-devtools/python/python3-aiohttp-fast-url-dispatcher_0.3.0.bb
@@ -10,6 +10,6 @@ inherit pypi python_setuptools_build_meta python_poetry_core
 PYPI_PACKAGE = "aiohttp_fast_url_dispatcher"
 
 RDEPENDS:${PN} = "\
-	${PYTHON_PN}-core (>=3.8) \
-	${PYTHON_PN}-aiohttp (>= 3.8.5) \
+	python3-core (>=3.8) \
+	python3-aiohttp (>= 3.8.5) \
 "

--- a/recipes-devtools/python/python3-aiohttp-zlib-ng_0.1.1.bb
+++ b/recipes-devtools/python/python3-aiohttp-zlib-ng_0.1.1.bb
@@ -10,7 +10,7 @@ inherit pypi python_poetry_core
 PYPI_PACKAGE = "aiohttp_zlib_ng"
 
 RDEPENDS:${PN} = "\
-	${PYTHON_PN}-core (>= 3.8) \
-	${PYTHON_PN}-aiohttp (>= 3.8.5) \
-	${PYTHON_PN}-zlib-ng (>= 0.3.0) \
+	python3-core (>= 3.8) \
+	python3-aiohttp (>= 3.8.5) \
+	python3-zlib-ng (>= 0.3.0) \
 "

--- a/recipes-devtools/python/python3-aiorun_2023.7.2.bb
+++ b/recipes-devtools/python/python3-aiorun_2023.7.2.bb
@@ -11,5 +11,5 @@ inherit pypi python_flit_core
 PYPI_PACKAGE = "aiorun"
 
 RDEPENDS:${PN} += "\
-	${PYTHON_PN}-core (>= 3.7) \
+	python3-core (>= 3.7) \
 "

--- a/recipes-devtools/python/python3-anyio_3.6.2.bb
+++ b/recipes-devtools/python/python3-anyio_3.6.2.bb
@@ -11,6 +11,6 @@ SRC_URI += "file://0001-Patch-to-be-able-to-compile.patch"
 inherit pypi python_setuptools_build_meta
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-idna (>=2.8) \
-    ${PYTHON_PN}-sniffio (>=1.1) \
+    python3-idna (>=2.8) \
+    python3-sniffio (>=1.1) \
 "

--- a/recipes-devtools/python/python3-astral_2.2.bb
+++ b/recipes-devtools/python/python3-astral_2.2.bb
@@ -9,7 +9,7 @@ SRC_URI[sha256sum] = "e41d9967d5c48be421346552f0f4dedad43ff39a83574f5ff2ad32b662
 inherit setuptools3 pypi
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-pytz \
-    ${PYTHON_PN}-tzdata \
-    ${PYTHON_PN}-zoneinfo \
+    python3-pytz \
+    python3-tzdata \
+    python3-zoneinfo \
 "

--- a/recipes-devtools/python/python3-async-upnp-client_0.36.2.bb
+++ b/recipes-devtools/python/python3-async-upnp-client_0.36.2.bb
@@ -12,10 +12,10 @@ S = "${WORKDIR}/async_upnp_client-${PV}"
 SRC_URI[sha256sum] = "0ba5d0b2560ed81b9cbb2960ecef20a9b560d65d75b36f9ccfe4ac0090c10323"
 
 RDEPENDS:${PN} = "\
-	${PYTHON_PN}-core (>=3.8) \
-	${PYTHON_PN}-async-timeout (>=3.0.0) \
-	${PYTHON_PN}-aiohttp (>=3.8.1) \
-	${PYTHON_PN}-python-didl-lite (=1.3.2) \
-	${PYTHON_PN}-defusedxml (>=0.6.0) \
-	${PYTHON_PN}-voluptuous (>=0.12.1) \
+	python3-core (>=3.8) \
+	python3-async-timeout (>=3.0.0) \
+	python3-aiohttp (>=3.8.1) \
+	python3-python-didl-lite (=1.3.2) \
+	python3-defusedxml (>=0.6.0) \
+	python3-voluptuous (>=0.12.1) \
 "

--- a/recipes-devtools/python/python3-axis_48.bb
+++ b/recipes-devtools/python/python3-axis_48.bb
@@ -8,10 +8,10 @@ SRC_URI[sha256sum] = "512ddfdf0e010b7cf45a25b9a3a9be458d3f2ad3dc73e4c8f407ea4f85
 inherit pypi setuptools3
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-async-timeout (>=4.0.2) \
-    ${PYTHON_PN}-attrs (>=23.1.0) \
-    ${PYTHON_PN}-httpx (>=0.24.0) \
-    ${PYTHON_PN}-orjson (>=3.8.10) \
-    ${PYTHON_PN}-packaging (>=23.1) \
-    ${PYTHON_PN}-xmltodict (=0.13.0) \
+    python3-async-timeout (>=4.0.2) \
+    python3-attrs (>=23.1.0) \
+    python3-httpx (>=0.24.0) \
+    python3-orjson (>=3.8.10) \
+    python3-packaging (>=23.1) \
+    python3-xmltodict (=0.13.0) \
 "

--- a/recipes-devtools/python/python3-bleak-retry-connector_3.3.0.bb
+++ b/recipes-devtools/python/python3-bleak-retry-connector_3.3.0.bb
@@ -10,9 +10,9 @@ PYPI_PACKAGE = "bleak_retry_connector"
 inherit pypi python_setuptools_build_meta python_poetry_core
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-core (>=3.10) \
-    ${PYTHON_PN}-async-timeout (>=4.0.1) \
-    ${PYTHON_PN}-bleak (>=0.21.0) \
-    ${PYTHON_PN}-bluetooth-adapters (>=0.15.2) \
-    ${PYTHON_PN}-dbus-fast (>=1.14.0) \
+    python3-core (>=3.10) \
+    python3-async-timeout (>=4.0.1) \
+    python3-bleak (>=0.21.0) \
+    python3-bluetooth-adapters (>=0.15.2) \
+    python3-dbus-fast (>=1.14.0) \
 "

--- a/recipes-devtools/python/python3-bluetooth-adapters_0.16.1.bb
+++ b/recipes-devtools/python/python3-bluetooth-adapters_0.16.1.bb
@@ -10,11 +10,11 @@ PYPI_PACKAGE = "bluetooth_adapters"
 inherit pypi python_setuptools_build_meta python_poetry_core
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-core (>3.9) \
-    ${PYTHON_PN}-aiohttp (>=3.8.1) \
-    ${PYTHON_PN}-async-timeout (>=4.0.2) \
-    ${PYTHON_PN}-bleak (>=0.15.1)) \
-    ${PYTHON_PN}-dbus-fast (>=1.21.0) \
-    ${PYTHON_PN}-mac-vendor-lookup (>=0.1.12) \
-    ${PYTHON_PN}-usb-devices (>=0.4.1) \
+    python3-core (>3.9) \
+    python3-aiohttp (>=3.8.1) \
+    python3-async-timeout (>=4.0.2) \
+    python3-bleak (>=0.15.1)) \
+    python3-dbus-fast (>=1.21.0) \
+    python3-mac-vendor-lookup (>=0.1.12) \
+    python3-usb-devices (>=0.4.1) \
 "

--- a/recipes-devtools/python/python3-bluetooth-auto-recovery_1.2.3.bb
+++ b/recipes-devtools/python/python3-bluetooth-auto-recovery_1.2.3.bb
@@ -10,10 +10,10 @@ PYPI_PACKAGE = "bluetooth_auto_recovery"
 inherit pypi python_setuptools_build_meta python_poetry_core
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-core (>3.9) \
-    ${PYTHON_PN}-async-timeout (>=4.0.1) \
-    ${PYTHON_PN}-btsocket (>=0.2.0) \
-    ${PYTHON_PN}-pyric (>=0.1.6.3) \
-    ${PYTHON_PN}-usb-devices (>=0.4.1) \
-    ${PYTHON_PN}-bluetooth-adapters (>=0.16.0) \
+    python3-core (>3.9) \
+    python3-async-timeout (>=4.0.1) \
+    python3-btsocket (>=0.2.0) \
+    python3-pyric (>=0.1.6.3) \
+    python3-usb-devices (>=0.4.1) \
+    python3-bluetooth-adapters (>=0.16.0) \
 "

--- a/recipes-devtools/python/python3-bluetooth-data-tools_1.15.0.bb
+++ b/recipes-devtools/python/python3-bluetooth-data-tools_1.15.0.bb
@@ -8,11 +8,11 @@ SRC_URI[sha256sum] = "713b6377f89e83bcbce8e12b940ba10c7496b21dc608e9433489ccc5ea
 PYPI_PACKAGE = "bluetooth_data_tools"
 
 DEPENDS += "\
-    ${PYTHON_PN}-cython-native \
+    python3-cython-native \
 "
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-core (>=3.10) \
+    python3-core (>=3.10) \
 "
 
 inherit pypi python_setuptools_build_meta python_poetry_core

--- a/recipes-devtools/python/python3-boto3_1.28.17.bb
+++ b/recipes-devtools/python/python3-boto3_1.28.17.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "90f7cfb5e1821af95b1fc084bc50e6c47fa3edc99f32de1a2591faa0c546bea7"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-botocore (>=1.31.17) \
-    ${PYTHON_PN}-jmespath (>=0.7.1) \
-    ${PYTHON_PN}-s3transfer (>=0.6.0) \
+    python3-botocore (>=1.31.17) \
+    python3-jmespath (>=0.7.1) \
+    python3-s3transfer (>=0.6.0) \
 "

--- a/recipes-devtools/python/python3-botocore_1.31.17.bb
+++ b/recipes-devtools/python/python3-botocore_1.31.17.bb
@@ -9,14 +9,14 @@ SRC_URI[sha256sum] = "396459065dba4339eb4da4ec8b4e6599728eb89b7caaceea199e26f7d8
 inherit pypi setuptools3
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-jmespath \
-    ${PYTHON_PN}-dateutil \
-    ${PYTHON_PN}-docutils \
-    ${PYTHON_PN}-shell \
-    ${PYTHON_PN}-netserver \
-    ${PYTHON_PN}-email \
-    ${PYTHON_PN}-json \
-    ${PYTHON_PN}-numbers \
-    ${PYTHON_PN}-html \
-    ${PYTHON_PN}-urllib3 \
+    python3-jmespath \
+    python3-dateutil \
+    python3-docutils \
+    python3-shell \
+    python3-netserver \
+    python3-email \
+    python3-json \
+    python3-numbers \
+    python3-html \
+    python3-urllib3 \
 " 

--- a/recipes-devtools/python/python3-ciso8601_2.3.0.bb
+++ b/recipes-devtools/python/python3-ciso8601_2.3.0.bb
@@ -8,5 +8,5 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "19e3fbd786d8bec3358eac94d8774d365b694b604fd1789244b87083f66c8900"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-pytz \
+    python3-pytz \
 "

--- a/recipes-devtools/python/python3-fnv-hash-fast_0.5.0.bb
+++ b/recipes-devtools/python/python3-fnv-hash-fast_0.5.0.bb
@@ -8,11 +8,11 @@ inherit pypi python_poetry_core
 PYPI_PACKAGE = "fnv_hash_fast"
 
 DEPENDS += "\
-    ${PYTHON_PN}-cython-native \
+    python3-cython-native \
 "
 
 SRC_URI[sha256sum] = "a84d658952776a186418f4158fc8e55ff3c576ac32cc9ef7f8077efdf2d0b89f"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-fnvhash (>=0.1.0) \
+    python3-fnvhash (>=0.1.0) \
 "

--- a/recipes-devtools/python/python3-fritzconnection_1.13.2.bb
+++ b/recipes-devtools/python/python3-fritzconnection_1.13.2.bb
@@ -8,5 +8,5 @@ SRC_URI[sha256sum] = "ccc7ff207bb599394dfc19da29c8c54679e318d2b9304f3263a52cb9f4
 inherit pypi setuptools3
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-requests (>=2.22.0) \
+    python3-requests (>=2.22.0) \
 "

--- a/recipes-devtools/python/python3-gtts_2.2.4.bb
+++ b/recipes-devtools/python/python3-gtts_2.2.4.bb
@@ -13,7 +13,7 @@ SRCREV = "d57db26b60286e7f684d32e305757d5587005eee"
 S = "${WORKDIR}/git"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-click \
-    ${PYTHON_PN}-requests \
-    ${PYTHON_PN}-six \
+    python3-click \
+    python3-requests \
+    python3-six \
 "

--- a/recipes-devtools/python/python3-ha-av_10.1.1.bb
+++ b/recipes-devtools/python/python3-ha-av_10.1.1.bb
@@ -9,11 +9,11 @@ SRC_URI[sha256sum] = "41a30556f8258a9374906d7e65034a93b593c9d4b220f9f6a9adf652db
 inherit pypi python_setuptools_build_meta pkgconfig
 
 DEPENDS += "\
-    ${PYTHON_PN}-cython-native \
+    python3-cython-native \
     ffmpeg \
 "
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-numpy \
-    ${PYTHON_PN}-pillow \
+    python3-numpy \
+    python3-pillow \
 "

--- a/recipes-devtools/python/python3-home-assistant-chip-clusters_2023.10.2.bb
+++ b/recipes-devtools/python/python3-home-assistant-chip-clusters_2023.10.2.bb
@@ -32,8 +32,8 @@ do_install() {
 }
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-aenum \
-    ${PYTHON_PN}-dacite \
+    python3-aenum \
+    python3-dacite \
 "
 
 FILES:${PN} += "\

--- a/recipes-devtools/python/python3-httpcore_0.18.0.bb
+++ b/recipes-devtools/python/python3-httpcore_0.18.0.bb
@@ -12,8 +12,8 @@ SRC_URI[sha256sum] = "13b5e5cd1dca1a6636a6aaea212b19f4f85cd88c366a2b82304181b769
 inherit pypi python_hatchling
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-anyio (>=3.0) \
-    ${PYTHON_PN}-certifi \
-    ${PYTHON_PN}-h11 (>=0.13) \
-    ${PYTHON_PN}-sniffio (>=1.0.0) \
+    python3-anyio (>=3.0) \
+    python3-certifi \
+    python3-h11 (>=0.13) \
+    python3-sniffio (>=1.0.0) \
 "

--- a/recipes-devtools/python/python3-httpx_0.25.0.bb
+++ b/recipes-devtools/python/python3-httpx_0.25.0.bb
@@ -12,8 +12,8 @@ SRC_URI[sha256sum] = "47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad23257197
 inherit pypi python_hatchling
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-certifi \
-    ${PYTHON_PN}-httpcore (>=0.18.0) \
-    ${PYTHON_PN}-idna \
-    ${PYTHON_PN}-sniffio \
+    python3-certifi \
+    python3-httpcore (>=0.18.0) \
+    python3-idna \
+    python3-sniffio \
 "

--- a/recipes-devtools/python/python3-janus_1.0.0.bb
+++ b/recipes-devtools/python/python3-janus_1.0.0.bb
@@ -9,5 +9,5 @@ SRC_URI[sha256sum] = "df976f2cdcfb034b147a2d51edfc34ff6bfb12d4e2643d3ad0e10de058
 inherit pypi python_setuptools_build_meta
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-typing-extensions (>=3.7.4.3) \
+    python3-typing-extensions (>=3.7.4.3) \
 "

--- a/recipes-devtools/python/python3-josepy_1.13.0.bb
+++ b/recipes-devtools/python/python3-josepy_1.13.0.bb
@@ -9,6 +9,6 @@ SRC_URI[md5sum] = "d0f8dc9ffbf3ce0bd9c40e5ec1bf3516"
 SRC_URI[sha256sum] = "8931daf38f8a4c85274a0e8b7cb25addfd8d1f28f9fb8fbed053dd51aec75dc9"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-cryptography (>=1.5) \
-    ${PYTHON_PN}-pyopenssl (>=0.13) \
+    python3-cryptography (>=1.5) \
+    python3-pyopenssl (>=0.13) \
 "

--- a/recipes-devtools/python/python3-mac-vendor-lookup_0.1.12.bb
+++ b/recipes-devtools/python/python3-mac-vendor-lookup_0.1.12.bb
@@ -15,8 +15,8 @@ S = "${WORKDIR}/git"
 inherit python_setuptools_build_meta
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiofiles \
-    ${PYTHON_PN}-aiohttp \
+    python3-aiofiles \
+    python3-aiohttp \
 "
 
 FILES:${PN} += "\

--- a/recipes-devtools/python/python3-mashumaro_3.10.bb
+++ b/recipes-devtools/python/python3-mashumaro_3.10.bb
@@ -14,7 +14,7 @@ PACKAGECONFIG[tomlpython-version-smaller-3-dot-11] = ",,,python3-tomli"
 PACKAGECONFIG[yaml] = ",,,python3-pyyaml"
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-typing-extensions (>=4.1.0) \
+    python3-typing-extensions (>=4.1.0) \
 "
 
 PYPI_PACKAGE = "mashumaro"

--- a/recipes-devtools/python/python3-mutagen_1.47.0.bb
+++ b/recipes-devtools/python/python3-mutagen_1.47.0.bb
@@ -8,5 +8,5 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99"
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-core (>=3.7) \
+    python3-core (>=3.7) \
 "

--- a/recipes-devtools/python/python3-pycognito_2023.5.0.bb
+++ b/recipes-devtools/python/python3-pycognito_2023.5.0.bb
@@ -8,8 +8,8 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "3843cfff56969f7c4b0b2fd499877941d0bf33e39c4541dc896c2b83bef5db24"
 
 RDEPENDS:${PN} = "\
-	${PYTHON_PN}-boto3 (>=1.10.49) \
-	${PYTHON_PN}-requests (>=2.22.0) \
-	${PYTHON_PN}-envs (>=1.3) \
-	${PYTHON_PN}-python-jose-cryptography (>=3.2.0) \
+	python3-boto3 (>=1.10.49) \
+	python3-requests (>=2.22.0) \
+	python3-envs (>=1.3) \
+	python3-python-jose-cryptography (>=3.2.0) \
 "

--- a/recipes-devtools/python/python3-pyfritzhome_0.6.9.bb
+++ b/recipes-devtools/python/python3-pyfritzhome_0.6.9.bb
@@ -8,5 +8,5 @@ SRC_URI[sha256sum] = "99adab96b2e21765b01afc35bd37159ef50c8e2387a4436b3125489174
 inherit pypi setuptools3
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-requests \
+    python3-requests \
 "

--- a/recipes-devtools/python/python3-pyipp_0.14.4.bb
+++ b/recipes-devtools/python/python3-pyipp_0.14.4.bb
@@ -8,9 +8,9 @@ SRC_URI[sha256sum] = "6d70ded92f93232fadd942175ba52e8746653db62a1df4fde839bc900a
 inherit pypi python_setuptools_build_meta python_poetry_core
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiohttp (>=3.0.0) \
-    ${PYTHON_PN}-awesomeversion (>=21.10.1) \
-    ${PYTHON_PN}-backoff (>=2.2.0) \
-    ${PYTHON_PN}-deepmerge (>=1.1.0) \
-    ${PYTHON_PN}-yarl (>=1.6.0) \
+    python3-aiohttp (>=3.0.0) \
+    python3-awesomeversion (>=21.10.1) \
+    python3-backoff (>=2.2.0) \
+    python3-deepmerge (>=1.1.0) \
+    python3-yarl (>=1.6.0) \
 "

--- a/recipes-devtools/python/python3-pyoctoprintapi_0.1.12.bb
+++ b/recipes-devtools/python/python3-pyoctoprintapi_0.1.12.bb
@@ -8,5 +8,5 @@ SRC_URI[sha256sum] = "933e2195efe91d110253cf7650c7ac630e4f26b3456fede098765fbd9c
 inherit pypi setuptools3
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiohttp \
+    python3-aiohttp \
 "

--- a/recipes-devtools/python/python3-pyrfc3339_1.1.bb
+++ b/recipes-devtools/python/python3-pyrfc3339_1.1.bb
@@ -11,5 +11,5 @@ SRC_URI[md5sum] = "c829980738b8271b0179ffd0c41187b0"
 SRC_URI[sha256sum] = "81b8cbe1519cdb79bed04910dd6fa4e181faf8c88dff1e1b987b5f7ab23a5b1a"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-pytz \
+    python3-pytz \
 "

--- a/recipes-devtools/python/python3-python-didl-lite_1.3.2.bb
+++ b/recipes-devtools/python/python3-python-didl-lite_1.3.2.bb
@@ -9,5 +9,5 @@ SRC_URI[md5sum] = "cdd3cc450a767fc2aec1370c404f5a60"
 SRC_URI[sha256sum] = "88c0641d3140f7b05f1efd93f7c481fc62aa50d1e05e17f0e0a15bee025c4af1"
 
 RDEPENDS:${PN} = "\
-	${PYTHON_PN}-defusedxml (>=0.6.0) \
+	python3-defusedxml (>=0.6.0) \
 "

--- a/recipes-devtools/python/python3-python-jose-cryptography_3.2.0.bb
+++ b/recipes-devtools/python/python3-python-jose-cryptography_3.2.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1b2f485d31051eb5916a93212174c041"
 inherit pypi python_setuptools_build_meta
 
 DEPENDS += "\
-	${PYTHON_PN}-pytest-runner-native \
+	python3-pytest-runner-native \
 "
 
 PYPI_PACKAGE = "python-jose"
@@ -15,5 +15,5 @@ SRC_URI[md5sum] = "382a4da9ec39a3fb872fd1cf672b8a57"
 SRC_URI[sha256sum] = "4e4192402e100b5fb09de5a8ea6bcc39c36ad4526341c123d401e2561720335b"
 
 RDEPENDS:${PN} = "\
-	${PYTHON_PN}-pycryptodome \
+	python3-pycryptodome \
 "

--- a/recipes-devtools/python/python3-python-slugify_4.0.1.bb
+++ b/recipes-devtools/python/python3-python-slugify_4.0.1.bb
@@ -11,9 +11,9 @@ SRC_URI[md5sum] = "9725b833e9d537066890063a8a8e604b"
 SRC_URI[sha256sum] = "69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-pycryptodome (>=3.3.1) \
-    ${PYTHON_PN}-six (<2.0) \
-    ${PYTHON_PN}-ecdsa (<1.0) \
-    ${PYTHON_PN}-future (<1.0) \
-    ${PYTHON_PN}-text-unidecode (>=1.3) \
+    python3-pycryptodome (>=3.3.1) \
+    python3-six (<2.0) \
+    python3-ecdsa (<1.0) \
+    python3-future (<1.0) \
+    python3-text-unidecode (>=1.3) \
 "

--- a/recipes-devtools/python/python3-pyturbojpeg_1.7.1.bb
+++ b/recipes-devtools/python/python3-pyturbojpeg_1.7.1.bb
@@ -10,5 +10,5 @@ inherit pypi setuptools3
 PYPI_PACKAGE = "PyTurboJPEG"
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-numpy \
+    python3-numpy \
 "

--- a/recipes-devtools/python/python3-radios_0.2.0.bb
+++ b/recipes-devtools/python/python3-radios_0.2.0.bb
@@ -8,13 +8,13 @@ SRC_URI[sha256sum] = "617c8f3dfb5824fd268cfb9662967e76e4b7467285f4e22de90973296c
 inherit pypi python_setuptools_build_meta python_poetry_core
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiodns (>=3.0) \
-    ${PYTHON_PN}-aiohttp (>=3.0.0) \
-    ${PYTHON_PN}-awesomeversion (>=21.10.1) \
-    ${PYTHON_PN}-backoff (>=1.9.0) \
-    ${PYTHON_PN}-cachetools (>=4.0.0) \
-    ${PYTHON_PN}-mashumaro (>= 3.10) \
-    ${PYTHON_PN}-pycountry (>=22.1.10) \
-    ${PYTHON_PN}-core (>=3.11) \
-    ${PYTHON_PN}-yarl (>=1.6.0) \
+    python3-aiodns (>=3.0) \
+    python3-aiohttp (>=3.0.0) \
+    python3-awesomeversion (>=21.10.1) \
+    python3-backoff (>=1.9.0) \
+    python3-cachetools (>=4.0.0) \
+    python3-mashumaro (>= 3.10) \
+    python3-pycountry (>=22.1.10) \
+    python3-core (>=3.11) \
+    python3-yarl (>=1.6.0) \
 "

--- a/recipes-devtools/python/python3-s3transfer_0.6.0.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.6.0.bb
@@ -9,5 +9,5 @@ SRC_URI[sha256sum] = "2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca
 inherit pypi setuptools3
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-botocore (>=1.12.36) \
+    python3-botocore (>=1.12.36) \
 "

--- a/recipes-devtools/python/python3-securetar_2023.3.0.bb
+++ b/recipes-devtools/python/python3-securetar_2023.3.0.bb
@@ -8,5 +8,5 @@ SRC_URI[sha256sum] = "f362e338fcf572ac65d062b5e5c31067605362ed412d4f553ac2ed9efe
 inherit pypi setuptools3
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-cryptography \
+    python3-cryptography \
 "

--- a/recipes-devtools/python/python3-webrtc-noise-gain_1.2.3.bb
+++ b/recipes-devtools/python/python3-webrtc-noise-gain_1.2.3.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=2aa2bed6f8750823223a2c11d7bc90c5"
 
 DEPENDS += "\
-    ${PYTHON_PN}-pybind11-native \
+    python3-pybind11-native \
 "
 
 inherit pypi python_setuptools_build_meta

--- a/recipes-homeassistant/home-assistant-libs/python3-aioshelly_6.1.0.bb
+++ b/recipes-homeassistant/home-assistant-libs/python3-aioshelly_6.1.0.bb
@@ -8,9 +8,9 @@ SRC_URI[sha256sum] = "015461f2607b17b78eefa60d4b91283b97141fa63450fdcebfa0269516
 inherit pypi python_setuptools_build_meta
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-aiohttp \
-    ${PYTHON_PN}-bluetooth-data-tools (>=0.3.0) \
-    ${PYTHON_PN}-orjson (>=3.8.1) \
-    ${PYTHON_PN}-core (>=3.10) \
-    ${PYTHON_PN}-yarl \
+    python3-aiohttp \
+    python3-bluetooth-data-tools (>=0.3.0) \
+    python3-orjson (>=3.8.1) \
+    python3-core (>=3.10) \
+    python3-yarl \
 "

--- a/recipes-homeassistant/home-assistant-libs/python3-matter-server_5.0.0.bb
+++ b/recipes-homeassistant/home-assistant-libs/python3-matter-server_5.0.0.bb
@@ -10,12 +10,12 @@ inherit pypi python_setuptools_build_meta
 PYPI_PACKAGE = "python-matter-server"
 
 RDEPENDS:${PN} += "\
-	${PYTHON_PN}-aiohttp \
-	${PYTHON_PN}-aiorun \
-	${PYTHON_PN}-async-timeout \
-	${PYTHON_PN}-core (>= 3.10) \
-	${PYTHON_PN}-coloredlogs \
-	${PYTHON_PN}-dacite \
-	${PYTHON_PN}-orjson \
-	${PYTHON_PN}-home-assistant-chip-clusters (=2023.10.2) \
+	python3-aiohttp \
+	python3-aiorun \
+	python3-async-timeout \
+	python3-core (>= 3.10) \
+	python3-coloredlogs \
+	python3-dacite \
+	python3-orjson \
+	python3-home-assistant-chip-clusters (=2023.10.2) \
 "

--- a/recipes-homeassistant/home-assistant-libs/python3-psutil-home-assistant_0.0.1.bb
+++ b/recipes-homeassistant/home-assistant-libs/python3-psutil-home-assistant_0.0.1.bb
@@ -9,5 +9,5 @@ SRC_URI[sha256sum] = "ebe4f3a98d76d93a3140da2823e9ef59ca50a59761fdc453b30b4407c4
 inherit pypi python_setuptools_build_meta
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-psutil \
+    python3-psutil \
 "

--- a/recipes-homeassistant/homeassistant/include/3d-printing.inc
+++ b/recipes-homeassistant/homeassistant/include/3d-printing.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-octoprint = "1"
 RDEPENDS:${PN}-octoprint = "\
-    ${PYTHON_PN}-pyoctoprintapi (=0.1.12) \
+    python3-pyoctoprintapi (=0.1.12) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/hacs.inc
+++ b/recipes-homeassistant/homeassistant/include/hacs.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-hacs = "1"
 RDEPENDS:${PN}-hacs = "\
-    ${PYTHON_PN}-aiogithubapi (=22.10.1) \
+    python3-aiogithubapi (=22.10.1) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/history.inc
+++ b/recipes-homeassistant/homeassistant/include/history.inc
@@ -6,10 +6,10 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-recorder = "1"
 RDEPENDS:${PN}-recorder = "\
-    ${PYTHON_PN}-sqlite3 \
-    ${PYTHON_PN}-fnv-hash-fast (=0.5.0) \
-    ${PYTHON_PN}-sqlalchemy (>=2.0.22) \
-    ${PYTHON_PN}-psutil-home-assistant (=0.0.1) \
+    python3-sqlite3 \
+    python3-fnv-hash-fast (=0.5.0) \
+    python3-sqlalchemy (>=2.0.22) \
+    python3-psutil-home-assistant (=0.0.1) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/hub.inc
+++ b/recipes-homeassistant/homeassistant/include/hub.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-modbus = "1"
 RDEPENDS:${PN}-modbus = "\
-    ${PYTHON_PN}-pymodbus (>=3.5.4) \
+    python3-pymodbus (>=3.5.4) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/image-processing.inc
+++ b/recipes-homeassistant/homeassistant/include/image-processing.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-ffmpeg = "1"
 RDEPENDS:${PN}-ffmpeg = "\
-    ${PYTHON_PN}-ha-ffmpeg (=3.1.0) \
+    python3-ha-ffmpeg (=3.1.0) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/media-player.inc
+++ b/recipes-homeassistant/homeassistant/include/media-player.inc
@@ -7,12 +7,12 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-cast = "1"
 RDEPENDS:${PN}-cast = "\
-    ${PYTHON_PN}-pychromecast (>=13.0.8) \
+    python3-pychromecast (>=13.0.8) \
 "
 
 ALLOW_EMPTY:${PN}-vlc = "1"
 RDEPENDS:${PN}-vlc = "\
-    ${PYTHON_PN}-python-vlc (>=3.0.18122) \
+    python3-python-vlc (>=3.0.18122) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/multiple.inc
+++ b/recipes-homeassistant/homeassistant/include/multiple.inc
@@ -15,54 +15,54 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-axis = "1"
 RDEPENDS:${PN}-axis = "\
-    ${PYTHON_PN}-axis (=48) \
+    python3-axis (=48) \
 "
 
 ALLOW_EMPTY:${PN}-cloud = "1"
 RDEPENDS:${PN}-cloud = "\
-    ${PYTHON_PN}-hass-nabucasa (=0.74.0) \
+    python3-hass-nabucasa (=0.74.0) \
 "
 
 ALLOW_EMPTY:${PN}-fritz = "1"
 RDEPENDS:${PN}-fritz = "\
-    ${PYTHON_PN}-fritzconnection (=1.13.2) \
-    ${PYTHON_PN}-xmltodict (=0.13.0) \
+    python3-fritzconnection (=1.13.2) \
+    python3-xmltodict (=0.13.0) \
 "
 
 ALLOW_EMPTY:${PN}-fritzbox = "1"
 RDEPENDS:${PN}-fritzbox = "\
-    ${PYTHON_PN}-pyfritzhome (=0.6.9) \
+    python3-pyfritzhome (=0.6.9) \
 "
 
 ALLOW_EMPTY:${PN}-hue = "1"
 RDEPENDS:${PN}-hue = "\
-    ${PYTHON_PN}-aiohue (=4.7.0) \
+    python3-aiohue (=4.7.0) \
 "
 
 ALLOW_EMPTY:${PN}-matter = "1"
 RDEPENDS:${PN}-matter = "\
-    ${PYTHON_PN}-matter-server (=5.0.0) \
+    python3-matter-server (=5.0.0) \
 "
 
 ALLOW_EMPTY:${PN}-radio-browser = "1"
 RDEPENDS:${PN}-radio-browser = "\
-    ${PYTHON_PN}-radios (=0.2.0) \
+    python3-radios (=0.2.0) \
 "
 
 ALLOW_EMPTY:${PN}-shelly = "1"
 RDEPENDS:${PN}-shelly = "\
-    ${PYTHON_PN}-aioshelly (=6.1.0) \
+    python3-aioshelly (=6.1.0) \
 "
 
 ALLOW_EMPTY:${PN}-tts = "1"
 RDEPENDS:${PN}-tts = "\
-    ${PYTHON_PN}-mutagen (=1.47.0) \
+    python3-mutagen (=1.47.0) \
 "
 
 ALLOW_EMPTY:${PN}-upnp = "1"
 RDEPENDS:${PN}-upnp = "\
-    ${PYTHON_PN}-async-upnp-client (=0.36.2) \
-    ${PYTHON_PN}-getmac (=0.8.2) \
+    python3-async-upnp-client (=0.36.2) \
+    python3-getmac (=0.8.2) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/multiple.inc
+++ b/recipes-homeassistant/homeassistant/include/multiple.inc
@@ -36,7 +36,7 @@ RDEPENDS:${PN}-fritzbox = "\
 
 ALLOW_EMPTY:${PN}-hue = "1"
 RDEPENDS:${PN}-hue = "\
-    python3-aiohue (=4.7.0) \
+    python3-aiohue (>=4.7.0) \
 "
 
 ALLOW_EMPTY:${PN}-matter = "1"

--- a/recipes-homeassistant/homeassistant/include/network.inc
+++ b/recipes-homeassistant/homeassistant/include/network.inc
@@ -9,23 +9,23 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-dhcp = "1"
 RDEPENDS:${PN}-dhcp = "\
-    ${PYTHON_PN}-aiodiscover (=1.5.1) \
-    ${PYTHON_PN}-scapy (=2.5.0) \
+    python3-aiodiscover (=1.5.1) \
+    python3-scapy (=2.5.0) \
 "
 
 ALLOW_EMPTY:${PN}-route53 = "1"
 RDEPENDS:${PN}-route53 = "\
-    ${PYTHON_PN}-boto3 (>=1.28.17) \
+    python3-boto3 (>=1.28.17) \
 "
 
 ALLOW_EMPTY:${PN}-ssdp = "1"
 RDEPENDS:${PN}-ssdp = "\
-    ${PYTHON_PN}-async-upnp-client (=0.36.2) \
+    python3-async-upnp-client (=0.36.2) \
 "
 
 ALLOW_EMPTY:${PN}-zeroconf = "1"
 RDEPENDS:${PN}-zeroconf = "\
-    ${PYTHON_PN}-zeroconf (>=0.119.0) \
+    python3-zeroconf (>=0.119.0) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/none.inc
+++ b/recipes-homeassistant/homeassistant/include/none.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-file-upload = "1"
 RDEPENDS:${PN}-file-upload = "\
-    ${PYTHON_PN}-janus (=1.0.0) \
+    python3-janus (=1.0.0) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/other.inc
+++ b/recipes-homeassistant/homeassistant/include/other.inc
@@ -13,45 +13,45 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-backup = "1"
 RDEPENDS:${PN}-backup = "\
-    ${PYTHON_PN}-securetar (=2023.3.0) \
+    python3-securetar (=2023.3.0) \
 "
 
 ALLOW_EMPTY:${PN}-frontend = "1"
 RDEPENDS:${PN}-frontend = "\
-    ${PYTHON_PN}-home-assistant-frontend (=20231206.0) \
+    python3-home-assistant-frontend (=20231206.0) \
 "
 
 ALLOW_EMPTY:${PN}-hardware = "1"
 RDEPENDS:${PN}-hardware = "\
-    ${PYTHON_PN}-psutil-home-assistant (=0.0.1) \
+    python3-psutil-home-assistant (=0.0.1) \
 "
 
 ALLOW_EMPTY:${PN}-http = "1"
 RDEPENDS:${PN}-http = "\
-    ${PYTHON_PN}-aiohttp-cors (=0.7.0) \
+    python3-aiohttp-cors (=0.7.0) \
 "
 
 ALLOW_EMPTY:${PN}-image-upload = "1"
 RDEPENDS:${PN}-image-upload = "\
-    ${PYTHON_PN}-pillow (>=10.1.0) \
+    python3-pillow (>=10.1.0) \
 "
 
 ALLOW_EMPTY:${PN}-keyboard-remote = "1"
 RDEPENDS:${PN}-keyboard-remote = "\
-    ${PYTHON_PN}-evdev (>=1.6.1) \
-    ${PYTHON_PN}-asyncinotify (>=4.0.2) \
+    python3-evdev (>=1.6.1) \
+    python3-asyncinotify (>=4.0.2) \
 "
 
 ALLOW_EMPTY:${PN}-mobile-app = "1"
 RDEPENDS:${PN}-mobile-app = "\
-    ${PYTHON_PN}-pynacl (=1.5.0) \
+    python3-pynacl (=1.5.0) \
 "
 
 ALLOW_EMPTY:${PN}-stream = "1"
 RDEPENDS:${PN}-stream = "\
-    ${PYTHON_PN}-pyturbojpeg (=1.7.1) \
-    ${PYTHON_PN}-ha-av (=10.1.1) \
-    ${PYTHON_PN}-numpy (>=1.26.0) \
+    python3-pyturbojpeg (=1.7.1) \
+    python3-ha-av (=10.1.1) \
+    python3-numpy (>=1.26.0) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/sensor.inc
+++ b/recipes-homeassistant/homeassistant/include/sensor.inc
@@ -6,8 +6,8 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-scrape = "1"
 RDEPENDS:${PN}-scrape = "\
-    ${PYTHON_PN}-beautifulsoup4 (>=4.12.2) \
-    ${PYTHON_PN}-lxml (>=4.9.3) \
+    python3-beautifulsoup4 (>=4.12.2) \
+    python3-lxml (>=4.9.3) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/switch.inc
+++ b/recipes-homeassistant/homeassistant/include/switch.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-pulseaudio-loopback = "1"
 RDEPENDS:${PN}-pulseaudio-loopback = "\
-    ${PYTHON_PN}-pulsectl (>=23.5.2) \
+    python3-pulsectl (>=23.5.2) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/system-monitor.inc
+++ b/recipes-homeassistant/homeassistant/include/system-monitor.inc
@@ -8,17 +8,17 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-ipp = "1"
 RDEPENDS:${PN}-ipp = "\
-    ${PYTHON_PN}-pyipp (=0.14.4) \
+    python3-pyipp (=0.14.4) \
 "
 
 ALLOW_EMPTY:${PN}-sentry = "1"
 RDEPENDS:${PN}-sentry = "\
-    ${PYTHON_PN}-sentry-sdk (>=1.31.0) \
+    python3-sentry-sdk (>=1.31.0) \
 "
 
 ALLOW_EMPTY:${PN}-systemmonitor = "1"
 RDEPENDS:${PN}-systemmonitor = "\
-    ${PYTHON_PN}-psutil (>=5.9.6) \
+    python3-psutil (>=5.9.6) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/text-to-speech.inc
+++ b/recipes-homeassistant/homeassistant/include/text-to-speech.inc
@@ -7,12 +7,12 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-amazon-polly = "1"
 RDEPENDS:${PN}-amazon-polly = "\
-    ${PYTHON_PN}-boto3 (>=1.28.17) \
+    python3-boto3 (>=1.28.17) \
 "
 
 ALLOW_EMPTY:${PN}-google-translate = "1"
 RDEPENDS:${PN}-google-translate = "\
-    ${PYTHON_PN}-gtts (=2.2.4) \
+    python3-gtts (=2.2.4) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/utility.inc
+++ b/recipes-homeassistant/homeassistant/include/utility.inc
@@ -7,18 +7,18 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-bluetooth = "1"
 RDEPENDS:${PN}-bluetooth = "\
-    ${PYTHON_PN}-bleak (=0.21.1) \
-    ${PYTHON_PN}-bleak-retry-connector (=3.3.0) \
-    ${PYTHON_PN}-bluetooth-adapters (=0.16.1) \
-    ${PYTHON_PN}-bluetooth-auto-recovery (=1.2.3) \
-    ${PYTHON_PN}-bluetooth-data-tools (=1.15.0) \
-    ${PYTHON_PN}-dbus-fast (>=2.12.0) \
+    python3-bleak (=0.21.1) \
+    python3-bleak-retry-connector (=3.3.0) \
+    python3-bluetooth-adapters (=0.16.1) \
+    python3-bluetooth-auto-recovery (=1.2.3) \
+    python3-bluetooth-data-tools (=1.15.0) \
+    python3-dbus-fast (>=2.12.0) \
 "
 
 ALLOW_EMPTY:${PN}-usb = "1"
 RDEPENDS:${PN}-usb = "\
-    ${PYTHON_PN}-pyserial (=3.5) \
-    ${PYTHON_PN}-pyudev (>=0.23.2) \
+    python3-pyserial (=3.5) \
+    python3-pyudev (>=0.23.2) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/voice.inc
+++ b/recipes-homeassistant/homeassistant/include/voice.inc
@@ -7,13 +7,13 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-assist-pipeline = "1"
 RDEPENDS:${PN}-assist-pipeline = "\
-    ${PYTHON_PN}-webrtc-noise-gain (>=1.2.3) \
+    python3-webrtc-noise-gain (>=1.2.3) \
 "
 
 ALLOW_EMPTY:${PN}-conversation = "1"
 RDEPENDS:${PN}-conversation = "\
-    ${PYTHON_PN}-hassil (>=1.2.5) \
-    ${PYTHON_PN}-home-assistant-intents (>=2023.12.5) \
+    python3-hassil (>=1.2.5) \
+    python3-home-assistant-intents (>=2023.12.5) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/include/weather.inc
+++ b/recipes-homeassistant/homeassistant/include/weather.inc
@@ -6,7 +6,7 @@ PACKAGES += "\
 
 ALLOW_EMPTY:${PN}-met = "1"
 RDEPENDS:${PN}-met = "\
-    ${PYTHON_PN}-pymetno (>=0.11.0) \
+    python3-pymetno (>=0.11.0) \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-homeassistant/homeassistant/python3-hassil_1.5.1.bb
+++ b/recipes-homeassistant/homeassistant/python3-hassil_1.5.1.bb
@@ -8,6 +8,6 @@ inherit pypi python_setuptools_build_meta
 SRC_URI[sha256sum] = "18bbc34fc05406f133822a8a697a2417dd768377ce1fe2ac5e799e3972307bd5"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-pyyaml (>=6.0) \
-    ${PYTHON_PN}-unicode-rbnf (=1.0.0) \
+    python3-pyyaml (>=6.0) \
+    python3-unicode-rbnf (=1.0.0) \
 "

--- a/recipes-homeassistant/homeassistant/python3-home-assistant-intents_2023.12.5.bb
+++ b/recipes-homeassistant/homeassistant/python3-home-assistant-intents_2023.12.5.bb
@@ -9,10 +9,10 @@ SRC_URI += "file://0001-Patch-pyproject.toml-to-use-upstream-version-of-setu.pat
 SRC_URI[sha256sum] = "d6d440af78cf1cfb8dff49168f9cd7970abe0e4b23f17631f7427a414b3b6867"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-hassil (>=1.5.1) \
-    ${PYTHON_PN}-pyyaml (>=6.0.1) \
-    ${PYTHON_PN}-voluptuous (=0.13.1) \
-    ${PYTHON_PN}-regex (>=2023.10.3) \
-    ${PYTHON_PN}-jinja2 (>=3.1.2) \
-    ${PYTHON_PN}-core (>=3.9.0) \
+    python3-hassil (>=1.5.1) \
+    python3-pyyaml (>=6.0.1) \
+    python3-voluptuous (=0.13.1) \
+    python3-regex (>=2023.10.3) \
+    python3-jinja2 (>=3.1.2) \
+    python3-core (>=3.9.0) \
 "

--- a/recipes-homeassistant/homeassistant/python3-homeassistant_2023.12.0.bb
+++ b/recipes-homeassistant/homeassistant/python3-homeassistant_2023.12.0.bb
@@ -66,37 +66,37 @@ require recipes-homeassistant/homeassistant/include/multiple.inc
 require recipes-homeassistant/homeassistant/include/none.inc
 
 RDEPENDS:${PN} += "\
-    ${PYTHON_PN}-aiohttp (>=3.9.1) \
-    ${PYTHON_PN}-aiohttp-cors (=0.7.0) \
-    ${PYTHON_PN}-aiohttp-fast-url-dispatcher (=0.3.0) \
-    ${PYTHON_PN}-aiohttp-zlib-ng (=0.1.1) \
-    ${PYTHON_PN}-astral (=2.2) \
-    ${PYTHON_PN}-attrs (>=23.1.0) \
-    ${PYTHON_PN}-atomicwrites-homeassistant (=1.4.1) \
-    ${PYTHON_PN}-awesomeversion (>=23.11.0) \
-    ${PYTHON_PN}-bcrypt (>=4.0.1) \   
-    ${PYTHON_PN}-certifi (>=2021.5.30) \
-    ${PYTHON_PN}-ciso8601 (=2.3.0) \
-    ${PYTHON_PN}-httpx (=0.25.0) \
-    ${PYTHON_PN}-home-assistant-bluetooth (=1.10.4) \
-    ${PYTHON_PN}-ifaddr (=0.2.0) \
-    ${PYTHON_PN}-jinja2 (>=3.1.2) \
-    ${PYTHON_PN}-lru-dict (>=1.2.0) \
-    ${PYTHON_PN}-pyjwt (=2.8.0) \
-    ${PYTHON_PN}-cryptography (>=41.0.7) \
-    ${PYTHON_PN}-pyopenssl (>=23.2.0) \
-    ${PYTHON_PN}-orjson (=3.9.9) \
-    ${PYTHON_PN}-packaging (>=23.1) \
-    ${PYTHON_PN}-pip (>=21.3.1) \
-    ${PYTHON_PN}-python-slugify (=4.0.1) \
-    ${PYTHON_PN}-pyyaml (=6.0.1) \
-    ${PYTHON_PN}-requests (=2.31.0) \
-    ${PYTHON_PN}-typing-extensions (>=4.8.0) \
-    ${PYTHON_PN}-ulid-transform (=0.9.0) \
-    ${PYTHON_PN}-voluptuous (=0.13.1) \
-    ${PYTHON_PN}-voluptuous-serialize (=2.6.0) \
-    ${PYTHON_PN}-yarl (>=1.9.2) \
+    python3-aiohttp (>=3.9.1) \
+    python3-aiohttp-cors (=0.7.0) \
+    python3-aiohttp-fast-url-dispatcher (=0.3.0) \
+    python3-aiohttp-zlib-ng (=0.1.1) \
+    python3-astral (=2.2) \
+    python3-attrs (>=23.1.0) \
+    python3-atomicwrites-homeassistant (=1.4.1) \
+    python3-awesomeversion (>=23.11.0) \
+    python3-bcrypt (>=4.0.1) \   
+    python3-certifi (>=2021.5.30) \
+    python3-ciso8601 (=2.3.0) \
+    python3-httpx (=0.25.0) \
+    python3-home-assistant-bluetooth (=1.10.4) \
+    python3-ifaddr (=0.2.0) \
+    python3-jinja2 (>=3.1.2) \
+    python3-lru-dict (>=1.2.0) \
+    python3-pyjwt (=2.8.0) \
+    python3-cryptography (>=41.0.7) \
+    python3-pyopenssl (>=23.2.0) \
+    python3-orjson (=3.9.9) \
+    python3-packaging (>=23.1) \
+    python3-pip (>=21.3.1) \
+    python3-python-slugify (=4.0.1) \
+    python3-pyyaml (=6.0.1) \
+    python3-requests (=2.31.0) \
+    python3-typing-extensions (>=4.8.0) \
+    python3-ulid-transform (=0.9.0) \
+    python3-voluptuous (=0.13.1) \
+    python3-voluptuous-serialize (=2.6.0) \
+    python3-yarl (>=1.9.2) \
     \
-    ${PYTHON_PN}-statistics \
-    ${PYTHON_PN}-core (>=3.11.0) \
+    python3-statistics \
+    python3-core (>=3.11.0) \
 " 

--- a/recipes-homeassistant/nabucasa/python3-hass-nabucasa_0.74.0.bb
+++ b/recipes-homeassistant/nabucasa/python3-hass-nabucasa_0.74.0.bb
@@ -8,13 +8,13 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "2962d1666ccedfe6621c51f91b08b141ff391a588574aaadf67f2f0e5e2eba8c"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-core (>=3.10) \
-    ${PYTHON_PN}-pycognito (=2023.5.0) \
-    ${PYTHON_PN}-snitun (>=0.36.2) \
-    ${PYTHON_PN}-ciso8601 (>=2.3.0) \
-    ${PYTHON_PN}-acme (=2.7.1) \
-    ${PYTHON_PN}-cryptography (>=2.8) \
-    ${PYTHON_PN}-attrs (>=19.3) \
-    ${PYTHON_PN}-aiohttp (>=3.6.1) \
-    ${PYTHON_PN}-atomicwrites-homeassistant (=1.4.1) \ 
+    python3-core (>=3.10) \
+    python3-pycognito (=2023.5.0) \
+    python3-snitun (>=0.36.2) \
+    python3-ciso8601 (>=2.3.0) \
+    python3-acme (=2.7.1) \
+    python3-cryptography (>=2.8) \
+    python3-attrs (>=19.3) \
+    python3-aiohttp (>=3.6.1) \
+    python3-atomicwrites-homeassistant (=1.4.1) \ 
 "

--- a/recipes-homeassistant/nabucasa/python3-snitun_0.36.2.bb
+++ b/recipes-homeassistant/nabucasa/python3-snitun_0.36.2.bb
@@ -8,7 +8,7 @@ inherit pypi setuptools3
 SRC_URI[sha256sum] = "a51b4331acb77d72e6f9d6d34a9721d9411d09c804d75abbbccceb76d90076d1"
 
 RDEPENDS:${PN} = "\
-    ${PYTHON_PN}-attrs (>=18.2.0) \
-    ${PYTHON_PN}-async-timeout (>=3.0.1) \
-    ${PYTHON_PN}-cryptography (>=2.5) \
+    python3-attrs (>=18.2.0) \
+    python3-async-timeout (>=3.0.1) \
+    python3-cryptography (>=2.5) \
 "


### PR DESCRIPTION
Dropping all references to `${PYTHON_PN}` in favor of directly using `python3` as python2 support is now gone.

In line with work in Poky and meta-oe.

Continuation of prevous branch so waiting on merging of that one.