### PR TITLE
2024.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ on a OE target.
 
 If you need help or like to discuss a topic please join the [`#meta-homeassistant:matrix.org`](https://matrix.to/#/#meta-homeassistant:matrix.org) room on [matrix.org](https://matrix.org/).
 
-
 Please see the corresponding sections below for details.
 
 # Quickstart
@@ -35,16 +34,11 @@ You should now be able to access Home Assistant via web browser usually under th
 
 The project provides files to quickly get started using [kas](https://github.com/siemens/kas).
 
-The two main entry points are `kas/homeassistant-master.yml` and `kas/homeassistant-mickledore.yml`.
+The two main entry points are `kas/homeassistant-main.yml` and `kas/homeassistant-main-full.yml`.
 
 To build against latest Yocto master use:
 ```
-kas build kas/homeassistant-master.yml
-```
-
-To build against latest Yocto mickledore use:
-```
-kas build kas/homeassistant-michledore.yml
+kas build kas/homeassistant-main.yml
 ```
 
 # Dependencies
@@ -65,6 +59,8 @@ Why are these needed?
 - [meta-python](https://github.com/openembedded/meta-openembedded/tree/mickledore/meta-python) : contains many of the required python3 packages
 - [meta-networking](https://github.com/openembedded/meta-openembedded/tree/mickledore/meta-networking) : contains several networking oriented python3 packages
 
+Note: HomeAssistant regularly uses the very latest versions of python packages in their builds. This also means that from a Yocto/OE perspective the team is forced to keep track of master as the very latest pushes to the dependency layers are often required for succesfull builds and satisfying dependency requirements. Therefore this repository tracks the upstream master branch and currently no older releases of Yocto are specifically supported.
+
 # Build configuration
 
 Home Assistant requires specific versions of some of its python dependencies. The recipe makes sure those dependencies are satisfied at root filesystem generation time but that doesn't give any gurantees that `bitbake` will pick a version that satisfies the version restriction in `RDEPENDS`. In order for the build to select the right versions, your distro file should include the version selection in `conf/distro/include/ha-versions.inc` when you are building `python3-homeassistant`. A sample distro (that can also be used as such, is provided - see `homeassistant.conf`).
@@ -80,12 +76,16 @@ So if you are missing something you can enforce it by specifically adding it to 
 # Layer structure
 The layer is structured in the following way:
 
-- recipes-homeassistant/homeassistant: contains the core recipe needed to run homeassistant via Yocto. Moreover it contains other recipe for components which are hosted here: https://github.com/home-assistant.
-- recipes-homeassistant/home-assistant-libs: contains recipes for components which are hosted by HA themselves at: https://github.com/home-assistant-libs
-- recipes-homeassistant/nabucasa: contains recipes for the HA cloud integration and which are hosted by HA at: https://github.com/NabuCasa/
+- kas: contains all kas configuration.
+- recipes-homeassistant/homeassistant: contains the core recipe needed to run homeassistant via Yocto
 - recipes-homeassistant/images: contains sample images to build
+- recipes-devtools: contains all Yocto python recipes which are needed for all the supported integrations.
+- recipes-multimedia: contains a backported older version of ffmpeg. Current master support version 7 but HomeAssistant does not yet.
+- scripts: convenience scripts for easier upgrades between versions.
 
-The recipes-devtools folder then contains all Yocto python recipes which do not fit the above categories. Most often these are other python dependencies.
+# Testing
+Ptest support is provided for homeassistant and all currently supported integrations. The list can be seen in `integrations-test.inc`.
+Homeassistant is tested with qemux86-64 architecture to see if all ptest pass before upgrading versions.
 
 # Contributing
 

--- a/recipes-devtools/python/python3-home-assistant-frontend/0001-Allowed-for-newer-wheel-version.patch
+++ b/recipes-devtools/python/python3-home-assistant-frontend/0001-Allowed-for-newer-wheel-version.patch
@@ -1,4 +1,4 @@
-From b0f123c0334cd1dedc3b0258d72f4b1a44944eaa Mon Sep 17 00:00:00 2001
+From 09a4f59e302671c57bb5060024b0d1674bfb32e9 Mon Sep 17 00:00:00 2001
 From: Tom Geelen <t.f.g.geelen@gmail.com>
 Date: Tue, 2 Jan 2024 23:32:08 +0000
 Subject: [PATCH] Allowed for newer wheel version
@@ -10,7 +10,7 @@ Upstream-Status: Pending
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index feff691..99ef026 100644
+index 4a9b64a..43b8f63 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -1,5 +1,5 @@

--- a/recipes-devtools/python/python3-home-assistant-frontend_20241002.4.bb
+++ b/recipes-devtools/python/python3-home-assistant-frontend_20241002.4.bb
@@ -10,7 +10,7 @@ PYPI_SRC_URI = "https://github.com/home-assistant/frontend/releases/download/${P
 inherit pypi python_setuptools_build_meta
 
 SRC_URI += "file://0001-Allowed-for-newer-wheel-version.patch"
-SRC_URI[sha256sum] = "6c8a6c2fcb7dd5b383e456d459eeba4d442fe8790a7efac6c88a952f2b60b91e"
+SRC_URI[sha256sum] = "63858acd68b71bd478b6691c74de3b2f9d379b81d45d15a86ba623a3a1b382c3"
 
 RDEPENDS:${PN} += " \
     python3-core (>=3.11) \

--- a/recipes-homeassistant/homeassistant/python3-homeassistant/0001-Allow-newer-version-of-setuptools.patch
+++ b/recipes-homeassistant/homeassistant/python3-homeassistant/0001-Allow-newer-version-of-setuptools.patch
@@ -1,4 +1,4 @@
-From f8c4a893f2b930629975437122bb7d9ee5bd4174 Mon Sep 17 00:00:00 2001
+From ffa8485caa50b1fb6bfb293e18f54a8d70afe0f3 Mon Sep 17 00:00:00 2001
 From: Tom Geelen <t.f.g.geelen@gmail.com>
 Date: Sun, 5 May 2024 15:24:46 +0000
 Subject: [PATCH] Allow newer version of setuptools
@@ -10,7 +10,7 @@ Upstream-Status: Pending
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index dd50e28be9..bf57df415d 100644
+index ccb1c38af5..0b82d4ebf4 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -1,5 +1,5 @@

--- a/recipes-homeassistant/homeassistant/python3-homeassistant/integrations.inc
+++ b/recipes-homeassistant/homeassistant/python3-homeassistant/integrations.inc
@@ -277,7 +277,7 @@ RDEPENDS:${PN}-fritzbox-callmonitor = "\
 
 ALLOW_EMPTY:${PN}-frontend = "1"
 RDEPENDS:${PN}-frontend = "\
-    python3-home-assistant-frontend (=20241002.3) \
+    python3-home-assistant-frontend (=20241002.4) \
 "
 
 ALLOW_EMPTY:${PN}-generic = "1"

--- a/recipes-homeassistant/homeassistant/python3-homeassistant_2024.10.4.bb
+++ b/recipes-homeassistant/homeassistant/python3-homeassistant_2024.10.4.bb
@@ -16,7 +16,7 @@ SRC_URI = "\
     file://run-ptest-sample \
 "
 SRC_URI[sha256sum] = "f4181f4023feb78cef0be655234200966daa140aea4634dbf3def8b18fd21d48"
-SRCREV = "a301d51fb2a69ce2b187a481d5cfa9b7cb30e453"
+SRCREV = "c09f15b0e9ef645c561410bd6e79543a92c1ccab"
 
 inherit python_setuptools_build_meta useradd systemd ptest
 


### PR DESCRIPTION
Added support for 2024.10.4

New integrations:

- N/A

Other changes:

- python3-home-assistant-frontend 20241002.3 -> 20241002.4
- Updated README: removed old information and clarified stance on which Yocto releases are supported. Added test strategy and mention of ptest support.