### PR TITLE
Kas & CI update

### DIFF
--- a/.github/workflows/kas.yml
+++ b/.github/workflows/kas.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     timeout-minutes: 360
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         yocto-version: [main]

--- a/.github/workflows/kas.yml
+++ b/.github/workflows/kas.yml
@@ -27,7 +27,7 @@ jobs:
         remove-swap: false
     - name: Install dependencies
       run: |
-        sudo apt install gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool file locales libacl1
+        sudo apt install gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit python3-websockets zstd liblz4-tool file locales libacl1
         sudo locale-gen en_US.UTF-8
         df -h
     - uses: actions/checkout@v1

--- a/.github/workflows/kas.yml
+++ b/.github/workflows/kas.yml
@@ -12,6 +12,11 @@ jobs:
         yocto-version: [main]
         machine: [qemu, container]
     steps:
+    - name: Setup unpriviledged user namespaces
+      # https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890
+      run: |
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
     - name: Reclaim the bytes
       uses: data-intuitive/reclaim-the-bytes@v2
       with:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ To build against latest Yocto master use:
 kas build kas/homeassistant-main.yml
 ```
 
+## Updating lock file
+
+The dependencies are locked to a given version. In order to update the layers run:
+
+```
+kas lock --update kas/homeassistant-main.yml
+kas lock --update kas/homeassistant-main-full.yml
+```
+
 # Dependencies
 
 ```
@@ -69,8 +78,8 @@ Also to note is that packages in HomeAssistant update very rapidly. This means t
 All missing recipes are backported into this layer to ensure functionality from meta-openembedded and poky.
 
 # Configuring HA
-Note that with `python3-homeassistant.bb` only the critical components are directly installed via `RDEPENDS`. 
-Any optional component is installed via `RRECOMMENDS`. 
+Note that with `python3-homeassistant.bb` only the critical components are directly installed via `RDEPENDS`.
+Any optional component is installed via `RRECOMMENDS`.
 So if you are missing something you can enforce it by specifically adding it to an `IMAGE_INSTALL`.
 
 # Layer structure

--- a/kas/ci.yml
+++ b/kas/ci.yml
@@ -1,7 +1,7 @@
 header:
   version: 14
 
-local_conf_header:  
+local_conf_header:
   reduce_diskspace: |
     INHERIT += "rm_work_and_downloads"
 
@@ -14,10 +14,10 @@ local_conf_header:
     DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
   Yocto Sstate cache: |
-    BB_SIGNATURE_HANDLER = "OEEquivHash"
+    BB_HASHSERVE_UPSTREAM = "wss://hashserv.yoctoproject.org/ws"
+    SSTATE_MIRRORS ?= "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"
     BB_HASHSERVE = "auto"
-    BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
-    SSTATE_MIRRORS:append = " file://.* https://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
+    BB_SIGNATURE_HANDLER = "OEEquivHash"
 
   Yocto Source mirror: |
     MIRRORS:append = "\

--- a/kas/homeassistant-main-full.lock.yml
+++ b/kas/homeassistant-main-full.lock.yml
@@ -1,0 +1,8 @@
+header:
+    version: 14
+overrides:
+    repos:
+        poky:
+            commit: c2da016918d1fda5bf63d94b59863f5013e482f9
+        meta-openembedded:
+            commit: 0623501548947e92ffd08625a112b8e7fb17a604

--- a/kas/homeassistant-main-full.yml
+++ b/kas/homeassistant-main-full.yml
@@ -1,31 +1,8 @@
 header:
   version: 14
+  includes:
+    - homeassistant-main.yml
 
 distro: homeassistant
 target: core-image-homeassistant-full
 
-repos:
-  meta-homeassistant:
-
-  poky:
-    url: https://git.yoctoproject.org/git/poky
-    branch: master
-    commit: "8d909f94a630ba582a81068dc1ea52ce3470c6fb"
-    layers:
-      meta:
-      meta-poky:
-
-  meta-openembedded:
-    url: http://git.openembedded.org/meta-openembedded
-    branch: master
-    layers:
-      meta-oe:
-      meta-python:
-      meta-networking:
-
-local_conf_header:
-
-  license_flags: |
-    LICENSE_FLAGS_ACCEPTED = "\
-      commercial_ffmpeg \
-    "

--- a/kas/homeassistant-main.lock.yml
+++ b/kas/homeassistant-main.lock.yml
@@ -1,0 +1,8 @@
+header:
+    version: 14
+overrides:
+    repos:
+        poky:
+            commit: c2da016918d1fda5bf63d94b59863f5013e482f9
+        meta-openembedded:
+            commit: 0623501548947e92ffd08625a112b8e7fb17a604

--- a/kas/homeassistant-main.yml
+++ b/kas/homeassistant-main.yml
@@ -10,7 +10,6 @@ repos:
   poky:
     url: https://git.yoctoproject.org/git/poky
     branch: master
-    commit: "8d909f94a630ba582a81068dc1ea52ce3470c6fb"
     layers:
       meta:
       meta-poky:


### PR DESCRIPTION
Updat the CI config to try getting it to work again.

- Update hash equivalent server
- Update to ubuntu 24.02 to make websockets work in python
- Use kas lock files to fixe poky and meta-oe versions