### PR TITLE
kas: renamed LICENSE_FLAGS_WHITELIST to LICENSE_FLAGS_ACCEPTED

### DIFF
--- a/kas/machine-raspberrypi3.yml
+++ b/kas/machine-raspberrypi3.yml
@@ -22,7 +22,7 @@ local_conf_header:
   raspberry: |
     RPI_USE_U_BOOT = "1"
     ENABLE_UART = "1"
-    LICENSE_FLAGS_WHITELIST = "commercial"
+    LICENSE_FLAGS_ACCEPTED = "commercial"
     IMAGE_INSTALL:append = " kernel-image kernel-modules"
 
   standard: |


### PR DESCRIPTION
Somewhere in the history of Yocto this variable was renamed.

Fixed:
  ERROR: Variable LICENSE_FLAGS_WHITELIST has been renamed to LICENSE_FLAGS_ACCEPTED