### PR TITLE
Streamline CI build

### DIFF
--- a/kas/ci.yml
+++ b/kas/ci.yml
@@ -5,14 +5,6 @@ local_conf_header:
   reduce_diskspace: |
     INHERIT += "rm_work_and_downloads"
 
-  Strip down unneeded features: |
-    POKY_DEFAULT_DISTRO_FEATURES:remove = "ptest"
-    POKY_DEFAULT_DISTRO_FEATURES:remove = "wayland"
-    DISTRO_FEATURES_DEFAULT:remove = "x11"
-    DISTRO_FEATURES:append = " systemd usrmerge"
-    VIRTUAL-RUNTIME_init_manager = "systemd"
-    DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
-
   Yocto Sstate cache: |
     BB_HASHSERVE_UPSTREAM = "wss://hashserv.yoctoproject.org/ws"
     SSTATE_MIRRORS ?= "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"

--- a/kas/homeassistant-main-full.lock.yml
+++ b/kas/homeassistant-main-full.lock.yml
@@ -1,8 +1,0 @@
-header:
-    version: 14
-overrides:
-    repos:
-        poky:
-            commit: c2da016918d1fda5bf63d94b59863f5013e482f9
-        meta-openembedded:
-            commit: 0623501548947e92ffd08625a112b8e7fb17a604

--- a/kas/homeassistant-main.lock.yml
+++ b/kas/homeassistant-main.lock.yml
@@ -3,6 +3,6 @@ header:
 overrides:
     repos:
         poky:
-            commit: c2da016918d1fda5bf63d94b59863f5013e482f9
+            commit: 8f69906d5ed64f2fa94ebe2f7215e5087bf1e6df
         meta-openembedded:
-            commit: 0623501548947e92ffd08625a112b8e7fb17a604
+            commit: 29897344f7c9846e00856f46c4b3b47117a69499

--- a/kas/homeassistant-main.yml
+++ b/kas/homeassistant-main.yml
@@ -1,8 +1,8 @@
 header:
   version: 14
 
-distro: homeassistant
-target: core-image-homeassistant
+distro: poky
+target: python3-homeassistant
 
 repos:
   meta-homeassistant:

--- a/kas/machine-container.yml
+++ b/kas/machine-container.yml
@@ -7,8 +7,6 @@ repos:
       meta-yocto-bsp:
 
 machine: genericx86-64
-distro: homeassistant
-target: container-homeassistant
 
 local_conf_header:
   container: |

--- a/kas/machine-qemu.yml
+++ b/kas/machine-qemu.yml
@@ -2,5 +2,3 @@ header:
   version: 14
 
 machine: qemuarm64
-distro: homeassistant
-target: core-image-homeassistant

--- a/kas/machine-raspberrypi3.lock.yml
+++ b/kas/machine-raspberrypi3.lock.yml
@@ -1,0 +1,10 @@
+header:
+    version: 14
+overrides:
+    repos:
+        meta-raspberrypi:
+            commit: 923ac579c78ca42d425c303c34b65e199470ef67
+        meta-swupdate:
+            commit: 66b195e6a879bd17f26878ab8d725b1e7b145322
+        meta-swupdate-boards:
+            commit: 67209aed77c0c4dff771f070a3e5f45410ae8449

--- a/scripts/kas-update-locks.sh
+++ b/scripts/kas-update-locks.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+kas lock --update kas/homeassistant-main.yml
+kas lock --update kas/machine-raspberrypi3.yml


### PR DESCRIPTION
- Only build python3-homeassistant
- Use Poky directly