### PR TITLE
kas: create a compressed wic file and bmap file

### DIFF
--- a/kas/machine-raspberrypi3.yml
+++ b/kas/machine-raspberrypi3.yml
@@ -43,5 +43,5 @@ local_conf_header:
     VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 
   swu-specific: |
-    IMAGE_FSTYPES += " ext4 ext4.gz ext4.zst wic"
+    IMAGE_FSTYPES += " ext4 ext4.gz ext4.zst wic.xz wic.bmap"
     WKS_FILES_raspberrypi3 = "ts-raspberrypi.wks"


### PR DESCRIPTION
Writing compressed wic files is possible with bmaptools without options. eg:
  `sudo bmaptool copy core-image-homeassistant-raspberrypi4.rootfs.wic.bz2 /dev/sda`

With the additional wic.bmap file, the writing to sdcard is much faster.