### PR TITLE
Python3 axis

### DIFF
--- a/recipes-devtools/python/python3-axis/0001-setuptools.patch
+++ b/recipes-devtools/python/python3-axis/0001-setuptools.patch
@@ -1,0 +1,35 @@
+From b0fe00f225acda7e81a8a3245fa3a6cc54643cad Mon Sep 17 00:00:00 2001
+From: "dependabot[bot]" <49699333+dependabot[bot]@users.noreply.github.com>
+Date: Mon, 6 Jan 2025 06:54:32 +0000
+Subject: [PATCH] Bump setuptools from 75.6.0 to 75.7.0
+
+Bumps [setuptools](https://github.com/pypa/setuptools) from 75.6.0 to 75.7.0.
+- [Release notes](https://github.com/pypa/setuptools/releases)
+- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
+- [Commits](https://github.com/pypa/setuptools/compare/v75.6.0...v75.7.0)
+
+---
+updated-dependencies:
+- dependency-name: setuptools
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Upstream-Status: Backport [b0fe00f225acda7e81a8a3245fa3a6cc54643cad]
+
+Signed-off-by: dependabot[bot] <support@github.com>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 44810840..b2517964 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools==75.6.0", "wheel==0.45.1"]
++requires = ["setuptools==75.7.0", "wheel==0.45.1"]
+ build-backend = "setuptools.build_meta"
+ 
+ [project]

--- a/recipes-devtools/python/python3-axis/0002-setuptools.patch
+++ b/recipes-devtools/python/python3-axis/0002-setuptools.patch
@@ -1,0 +1,35 @@
+From e4d976f02c790131f352ea99d6b06e7bcdcd8b83 Mon Sep 17 00:00:00 2001
+From: "dependabot[bot]" <49699333+dependabot[bot]@users.noreply.github.com>
+Date: Fri, 10 Jan 2025 06:38:35 +0000
+Subject: [PATCH] Bump setuptools from 75.7.0 to 75.8.0
+
+Bumps [setuptools](https://github.com/pypa/setuptools) from 75.7.0 to 75.8.0.
+- [Release notes](https://github.com/pypa/setuptools/releases)
+- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
+- [Commits](https://github.com/pypa/setuptools/compare/v75.7.0...v75.8.0)
+
+---
+updated-dependencies:
+- dependency-name: setuptools
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Upstream-Status: Backport [e4d976f02c790131f352ea99d6b06e7bcdcd8b83]
+
+Signed-off-by: dependabot[bot] <support@github.com>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 9770c21b..09305f21 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools==75.7.0", "wheel==0.45.1"]
++requires = ["setuptools==75.8.0", "wheel==0.45.1"]
+ build-backend = "setuptools.build_meta"
+ 
+ [project]

--- a/recipes-devtools/python/python3-axis_64.bb
+++ b/recipes-devtools/python/python3-axis_64.bb
@@ -3,7 +3,12 @@ HOMEPAGE = "https://github.com/Kane610/axis"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=78a6a0bb7d76993abedec7510368fb0e"
 
-SRC_URI += "${PYPI_SRC_URI}"
+SRC_URI += "\
+    ${PYPI_SRC_URI} \
+    file://0001-setuptools.patch \
+    file://0002-setuptools.patch \
+    "
+
 SRC_URI[sha256sum] = "12a70f61faec1599baad1b7a5ba8b182eea7c5e0ec8f0ca071e268b9759c8c7f"
 
 inherit pypi python_setuptools_build_meta


### PR DESCRIPTION
python3-setuptools is newer in Yocto/OE at master than what the release of python3-axis requested.
But the master of python3-axis does request the same version of Yocto/OE.