### PR TITLE
kas: override syntax update for WKS_FILES

### DIFF
--- a/kas/machine-raspberrypi3.yml
+++ b/kas/machine-raspberrypi3.yml
@@ -44,4 +44,4 @@ local_conf_header:
 
   swu-specific: |
     IMAGE_FSTYPES += " ext4 ext4.gz ext4.zst wic"
-    WKS_FILES_raspberrypi3 = "ts-raspberrypi.wks"
+    WKS_FILES:raspberrypi3 = "ts-raspberrypi.wks"


### PR DESCRIPTION
Without the kernel did boot, but the rootfs was not found.
Although I had to little logging to see where exact it was failing.