### PR TITLE
python3-home-assistant-frontend: relax setuptools requirement

### DIFF
--- a/recipes-devtools/python/python3-home-assistant-frontend/0001-relax-setuptools-version-requirement.patch
+++ b/recipes-devtools/python/python3-home-assistant-frontend/0001-relax-setuptools-version-requirement.patch
@@ -1,0 +1,22 @@
+From fa41f791df85209814b869f7cb72e3590d810097 Mon Sep 17 00:00:00 2001
+From: Tom Geelen <t.f.g.geelen@gmail.com>
+Date: Fri, 21 Mar 2025 14:08:43 +0000
+Subject: [PATCH] relax setuptools version requirement
+
+Signed-off-by: Tom Geelen <t.f.g.geelen@gmail.com>
+Upstream-Status: Pending
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index c4d13eb..23e77e4 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools~=75.1"]
++requires = ["setuptools>=75.1"]
+ build-backend = "setuptools.build_meta"
+ 
+ [project]

--- a/recipes-devtools/python/python3-home-assistant-frontend_20250109.2.bb
+++ b/recipes-devtools/python/python3-home-assistant-frontend_20250109.2.bb
@@ -11,6 +11,7 @@ inherit pypi python_setuptools_build_meta
 
 PYPI_PACKAGE = "home_assistant_frontend"
 
+SRC_URI += "file://0001-relax-setuptools-version-requirement.patch"
 SRC_URI[sha256sum] = "7b6ad116f6625449612a7301a76cc282ee61a74633d3e8b717b5e012216f5bf3"
 
 RDEPENDS:${PN} += "\


### PR DESCRIPTION
python3-home-assistant-frontend: relax setuptools requirement as there is a newer version available. This is failing the build