### PR TITLE
Repair failing cython packages

### DIFF
--- a/recipes-devtools/python/python3-dbus-fast/0001-relax-build-deps.patch
+++ b/recipes-devtools/python/python3-dbus-fast/0001-relax-build-deps.patch
@@ -1,0 +1,33 @@
+From 4ddaf954fd647d1945308a68fe786938e893b561 Mon Sep 17 00:00:00 2001
+From: Tom Geelen <t.f.g.geelen@gmail.com>
+Date: Thu, 15 May 2025 22:58:42 +0000
+Subject: [PATCH] relax build deps
+
+Signed-off-by: Tom Geelen <t.f.g.geelen@gmail.com>
+Upstream-Status: Pending
+---
+ pyproject.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index e22ea42..f670d3d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -50,7 +50,7 @@ pytest-cov = ">=3,<7"
+ pytest-asyncio = ">=0.19,<0.27"
+ pycairo = "^1.21.0"
+ PyGObject = {version = ">=3.50,<3.51", python = "<4"}
+-Cython = ">=3,<3.1.0"
++Cython = ">=3"
+ setuptools = ">=65.4.1,<79.0.0"
+ pytest-timeout = "^2.1.0"
+ pytest-codspeed = "^3.1.1"
+@@ -104,7 +104,7 @@ module = "docs.*"
+ ignore_errors = true
+ 
+ [build-system]
+-requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3,<3.1.0', "poetry-core>=1.0.0"]
++requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3', "poetry-core>=1.0.0"]
+ build-backend = "poetry.core.masonry.api"
+ 
+ [tool.ruff]

--- a/recipes-devtools/python/python3-dbus-fast_%.bbappend
+++ b/recipes-devtools/python/python3-dbus-fast_%.bbappend
@@ -1,4 +1,3 @@
-BBCLASSEXTEND = "native"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://0001-relax-build-deps.patch"

--- a/recipes-devtools/python/python3-propcache/0001-relax-build-deps.patch
+++ b/recipes-devtools/python/python3-propcache/0001-relax-build-deps.patch
@@ -1,0 +1,24 @@
+From e0a12c184463ccd8147e6dbed6034b884b8678c8 Mon Sep 17 00:00:00 2001
+From: Tom Geelen <t.f.g.geelen@gmail.com>
+Date: Thu, 15 May 2025 21:58:55 +0000
+Subject: [PATCH] relax build deps
+
+Signed-off-by: Tom Geelen <t.f.g.geelen@gmail.com>
+Upstream-Status: Pending
+---
+ packaging/pep517_backend/_backend.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packaging/pep517_backend/_backend.py b/packaging/pep517_backend/_backend.py
+index 7588db3..6d5d294 100644
+--- a/packaging/pep517_backend/_backend.py
++++ b/packaging/pep517_backend/_backend.py
+@@ -379,7 +379,7 @@ def get_requires_for_build_wheel(
+     elif sysconfig.get_config_var('Py_GIL_DISABLED'):
+         c_ext_build_deps = ['Cython ~= 3.1.0a1']
+     else:
+-        c_ext_build_deps = ['Cython ~= 3.0.12']
++        c_ext_build_deps = ['Cython >= 3.0.12']
+ 
+     return _setuptools_get_requires_for_build_wheel(
+         config_settings=config_settings,


### PR DESCRIPTION
Poky just pushed an upgrade of python3-cython: 3.1.0. (commit: c07c578e37d6ced3828343d881a861237d6db567). This breaks the following packages in a full homeassistant build.

python3-propcache: relax cython requirement

python3-dbus-fast: relax cython requirement